### PR TITLE
#14: add perf benchmark with multiplexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ cmds
 data
 *.log
 *.out
+plots
+scripts

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ install
 CMakeFiles
 output
 tests/logs/output
+cmds
+data
+*.log
+*.out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,11 @@ set(SLOW_NODE_EXE slow_node)
 add_executable(
   ${SLOW_NODE_EXE}
   "${CMAKE_SOURCE_DIR}/src/slow_node.cc"
+  "${CMAKE_SOURCE_DIR}/src/benchmarks.cc"
+  "${CMAKE_SOURCE_DIR}/src/perf_benchmark.cc"
   "${CMAKE_SOURCE_DIR}/src/sensors.cc"
   "${CMAKE_SOURCE_DIR}/src/freq.cc"
+  "${CMAKE_SOURCE_DIR}/src/perf.cc"
 )
 
 find_package(MPI REQUIRED)
@@ -29,4 +32,15 @@ else()
   message(STATUS "Did not find Trilinos. Searching for kokkos directly.")
   find_package(Kokkos REQUIRED)
   target_link_libraries(${SLOW_NODE_EXE} PUBLIC Kokkos::kokkos)
+endif()
+
+option(SLOWNODE_USE_VT "Use VT runtime" OFF)
+if (SLOWNODE_USE_VT)
+  find_package(vt)
+  if (vt_FOUND)
+    target_link_libraries(${SLOW_NODE_EXE} PUBLIC vt::runtime::vt)
+    target_compile_definitions(${SLOW_NODE_EXE} PUBLIC VT_ENABLED)
+  else()
+    message(WARNING "VT requested but not found. Continuing without VT support.")
+  endif()
 endif()

--- a/plot_perf_counters.py
+++ b/plot_perf_counters.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+from collections import defaultdict
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+
+def normalize_metric_name(metric_name):
+    return metric_name.strip().replace("arith_inst_retired_", "")
+
+
+def load_metric_data(csv_path, focus=None, exclude=None):
+    focus = set(focus or [])
+    exclude = set(exclude or [])
+    metric_values = defaultdict(list)
+
+    with csv_path.open("r", newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        if reader.fieldnames is None:
+            raise ValueError("CSV has no header row")
+
+        required_cols = {"rank", "hostname", "metric", "value"}
+        missing_cols = required_cols.difference(reader.fieldnames)
+        if missing_cols:
+            raise ValueError(
+                "CSV must contain header: rank,hostname,metric,value. "
+                f"Missing: {sorted(missing_cols)}"
+            )
+
+        for row_idx, row in enumerate(reader, start=2):
+            metric_name = (row.get("metric") or "").strip()
+            metric_name = normalize_metric_name(metric_name)
+            raw_value = (row.get("value") or "").strip()
+
+            if not metric_name or not raw_value:
+                continue
+
+            if metric_name in exclude:
+                continue
+
+            if focus and metric_name not in focus:
+                continue
+
+            try:
+                value = float(raw_value)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid numeric value '{raw_value}' at CSV line {row_idx}"
+                ) from exc
+
+            metric_values[metric_name].append(value)
+
+    if not metric_values:
+        raise ValueError("No metric data found in CSV")
+
+    return metric_values
+
+
+def load_ground_truth_data(csv_path, focus=None, exclude=None):
+    focus = set(focus or [])
+    exclude = set(exclude or [])
+    ground_truth = {}
+
+    with csv_path.open("r", newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        if reader.fieldnames is None:
+            raise ValueError("Ground-truth CSV has no header row")
+
+        required_cols = {"metric", "value"}
+        missing_cols = required_cols.difference(reader.fieldnames)
+        if missing_cols:
+            raise ValueError(
+                "Ground-truth CSV must contain header: metric,value. "
+                f"Missing: {sorted(missing_cols)}"
+            )
+
+        for row_idx, row in enumerate(reader, start=2):
+            metric_name = normalize_metric_name(row.get("metric") or "")
+            raw_value = (row.get("value") or "").strip()
+
+            if not metric_name or not raw_value:
+                continue
+
+            if metric_name in exclude:
+                continue
+
+            if focus and metric_name not in focus:
+                continue
+
+            try:
+                ground_truth[metric_name] = float(raw_value)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid ground-truth value '{raw_value}' at CSV line {row_idx}"
+                ) from exc
+
+    return ground_truth
+
+
+def infer_ground_truth_path(csv_path):
+    candidates = []
+    if csv_path.name.startswith("perf_metrics_"):
+        candidates.append(
+            csv_path.with_name(csv_path.name.replace("perf_metrics_", "perf_ground_truth_", 1))
+        )
+    candidates.append(csv_path.with_name(f"{csv_path.stem}_ground_truth{csv_path.suffix}"))
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    return None
+
+
+def resolve_ground_truth_path(csv_path, ground_truth_arg):
+    if ground_truth_arg == "none":
+        return None
+    if ground_truth_arg == "auto":
+        return infer_ground_truth_path(csv_path)
+    return Path(ground_truth_arg)
+
+
+def plot_metrics_boxplot(metric_values, output_path, logscale=False, ground_truth=None):
+    metric_names = sorted(metric_values.keys())
+    series = [metric_values[name] for name in metric_names]
+
+    fig_width = max(10, len(metric_names) * 1.2)
+    fig, ax = plt.subplots(figsize=(fig_width, 6.5))
+
+    ax.boxplot(
+        series,
+        tick_labels=metric_names,
+        patch_artist=True,
+        showfliers=True,
+        whis=(1, 99),
+    )
+
+    if ground_truth:
+        truth_x = []
+        truth_y = []
+        for idx, metric_name in enumerate(metric_names, start=1):
+            if metric_name not in ground_truth:
+                continue
+            value = ground_truth[metric_name]
+            if logscale and value <= 0.0:
+                continue
+            truth_x.append(idx)
+            truth_y.append(value)
+
+        if truth_x:
+            ax.scatter(
+                truth_x,
+                truth_y,
+                color="green",
+                edgecolors="black",
+                marker="o",
+                s=70,
+                zorder=4,
+                label="Ground truth",
+            )
+            ax.legend()
+
+    ax.set_xlabel("Metric")
+    ax.set_ylabel("Metric Value")
+    if logscale:
+        ax.set_yscale("log")
+    ax.set_title("Performance Counter Distributions by Metric")
+    ax.tick_params(axis="x", rotation=30)
+    ax.grid(axis="y", linestyle="--", alpha=0.4)
+
+    fig.tight_layout()
+    fig.savefig(output_path)
+    plt.close(fig)
+
+
+def arg_list(values):
+    return [value.strip() for value in values.split(",") if value.strip()] if values else []
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Plot per-metric box-and-whisker distributions from a perf CSV."
+    )
+    parser.add_argument(
+        "-i", "--input", required=True,
+        help="Path to input CSV containing metric name and value columns",
+    )
+    parser.add_argument(
+        "-l", "--logscale", action="store_true",
+        help="Use logarithmic scale for y-axis (default: False)",
+    )
+    parser.add_argument(
+        "-e", "--exclude", type=arg_list, default=[],
+        help="Metric names to exclude from the plot (default: none)",
+    )
+    parser.add_argument(
+        "-f", "--focus", type=arg_list, default=[],
+        help="Metric names to focus on in the plot (default: none)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="perf_plot.png",
+        help="Output plot path (default: perf_plot.png)",
+    )
+    parser.add_argument(
+        "--ground-truth",
+        default="auto",
+        help=(
+            "Ground-truth CSV path with metric,value columns. Use 'auto' to look for "
+            "perf_ground_truth_<benchmark>.csv next to the input, or 'none' to disable "
+            "the overlay (default: auto)."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    csv_path = Path(args.input)
+    if not csv_path.is_file():
+        raise FileNotFoundError(f"Input CSV not found: {csv_path}")
+
+    metric_values = load_metric_data(csv_path, focus=args.focus, exclude=args.exclude)
+    ground_truth_path = resolve_ground_truth_path(csv_path, args.ground_truth)
+    if ground_truth_path and not ground_truth_path.is_file():
+        raise FileNotFoundError(f"Ground-truth CSV not found: {ground_truth_path}")
+
+    ground_truth = None
+    if ground_truth_path:
+        ground_truth = load_ground_truth_data(
+            ground_truth_path,
+            focus=args.focus,
+            exclude=args.exclude,
+        )
+
+    plot_metrics_boxplot(
+        metric_values,
+        Path(args.output),
+        logscale=args.logscale,
+        ground_truth=ground_truth,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/plot_perf_metric.py
+++ b/plot_perf_metric.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import re
+from collections import defaultdict
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+
+SUBDIR_PATTERN = re.compile(r"^perf_(mp|nomp)_(\d+)r_(\d+)l$")
+VALID_TYPES = {"double", "complex"}
+
+
+def normalize_metric_name(metric_name):
+    return metric_name.strip().replace("arith_inst_retired_", "")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plot paired mp/nomp boxplots for one metric across loop counts "
+            "from perf benchmark output directories."
+        )
+    )
+    parser.add_argument(
+        "-d",
+        "--data-dir",
+        required=True,
+        help="Root data directory containing perf_[no]mp_[num_ranks]r_[num_loops]l subdirectories",
+    )
+    parser.add_argument(
+        "-m",
+        "--metric",
+        required=True,
+        help="Metric name to plot",
+    )
+    parser.add_argument(
+        "-t",
+        "--type",
+        default="double",
+        choices=sorted(VALID_TYPES),
+        help="Benchmark type: double or complex",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help="Output plot path (default: metric_<type>_<metric>.png)",
+    )
+    parser.add_argument(
+        "-l",
+        "--logscale",
+        action="store_true",
+        help="Use logarithmic scale for y-axis",
+    )
+    return parser.parse_args()
+
+
+def load_metric_series(csv_path, target_metric):
+    values = []
+
+    with csv_path.open("r", newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        if reader.fieldnames is None:
+            raise ValueError(f"CSV has no header row: {csv_path}")
+
+        required_cols = {"rank", "hostname", "metric", "value"}
+        missing_cols = required_cols.difference(reader.fieldnames)
+        if missing_cols:
+            raise ValueError(
+                f"CSV {csv_path} must contain header rank,hostname,metric,value. "
+                f"Missing: {sorted(missing_cols)}"
+            )
+
+        for row_idx, row in enumerate(reader, start=2):
+            metric_name = normalize_metric_name(row.get("metric") or "")
+            raw_value = (row.get("value") or "").strip()
+
+            if not metric_name or not raw_value:
+                continue
+
+            if metric_name != target_metric:
+                continue
+
+            try:
+                values.append(float(raw_value))
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid numeric value '{raw_value}' at line {row_idx} in {csv_path}"
+                ) from exc
+
+    return values
+
+
+def load_ground_truth_value(csv_path, target_metric):
+    with csv_path.open("r", newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        if reader.fieldnames is None:
+            raise ValueError(f"Ground-truth CSV has no header row: {csv_path}")
+
+        required_cols = {"metric", "value"}
+        missing_cols = required_cols.difference(reader.fieldnames)
+        if missing_cols:
+            raise ValueError(
+                f"Ground-truth CSV {csv_path} must contain header metric,value. "
+                f"Missing: {sorted(missing_cols)}"
+            )
+
+        for row_idx, row in enumerate(reader, start=2):
+            metric_name = normalize_metric_name(row.get("metric") or "")
+            raw_value = (row.get("value") or "").strip()
+
+            if not metric_name or not raw_value:
+                continue
+
+            if metric_name != target_metric:
+                continue
+
+            try:
+                return float(raw_value)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid ground-truth value '{raw_value}' at line {row_idx} in {csv_path}"
+                ) from exc
+
+    return None
+
+
+def collect_data(data_dir, bench_type, target_metric):
+    grouped = defaultdict(dict)
+
+    for subdir in sorted(data_dir.iterdir()):
+        if not subdir.is_dir():
+            continue
+
+        match = SUBDIR_PATTERN.match(subdir.name)
+        if not match:
+            continue
+
+        mode, num_ranks_str, num_loops_str = match.groups()
+        num_ranks = int(num_ranks_str)
+        num_loops = int(num_loops_str)
+
+        metrics_path = subdir / f"perf_metrics_{bench_type}.csv"
+        truth_path = subdir / f"perf_ground_truth_{bench_type}.csv"
+
+        if not metrics_path.is_file():
+            raise FileNotFoundError(f"Metrics CSV not found: {metrics_path}")
+        if not truth_path.is_file():
+            raise FileNotFoundError(f"Ground-truth CSV not found: {truth_path}")
+
+        metric_values = load_metric_series(metrics_path, target_metric)
+        ground_truth = load_ground_truth_value(truth_path, target_metric)
+
+        grouped[num_loops][mode] = {
+            "num_ranks": num_ranks,
+            "values": metric_values,
+            "ground_truth": ground_truth,
+            "source_dir": subdir,
+        }
+
+    if not grouped:
+        raise ValueError(f"No matching perf_* subdirectories found under {data_dir}")
+
+    return dict(sorted(grouped.items()))
+
+
+def plot_grouped_boxplots(grouped_data, metric_name, bench_type, output_path, logscale=False):
+    loops_sorted = sorted(grouped_data.keys())
+
+    positions = []
+    series = []
+    colors = []
+    tick_positions = []
+    tick_labels = []
+    truth_x = []
+    truth_y = []
+
+    width = 0.32
+    group_gap = 1.25
+
+    current_center = 1.0
+
+    for num_loops in loops_sorted:
+        group = grouped_data[num_loops]
+
+        mp_pos = current_center - 0.22
+        nomp_pos = current_center + 0.22
+
+        has_any = False
+
+        if "mp" in group and group["mp"]["values"]:
+            positions.append(mp_pos)
+            series.append(group["mp"]["values"])
+            colors.append("#4C72B0")
+            has_any = True
+
+        if "nomp" in group and group["nomp"]["values"]:
+            positions.append(nomp_pos)
+            series.append(group["nomp"]["values"])
+            colors.append("#DD8452")
+            has_any = True
+
+        tick_positions.append(current_center)
+        tick_labels.append(str(num_loops))
+
+        gt_value = None
+        for mode in ("mp", "nomp"):
+            if mode in group and group[mode]["ground_truth"] is not None:
+                gt_value = group[mode]["ground_truth"]
+                break
+
+        if gt_value is not None and (not logscale or gt_value > 0.0):
+            truth_x.append(current_center)
+            truth_y.append(gt_value)
+
+        if has_any:
+            current_center += group_gap
+
+    if not series:
+        raise ValueError(f"No data found for metric '{metric_name}'")
+
+    fig_width = max(10, len(loops_sorted) * 1.8)
+    fig, ax = plt.subplots(figsize=(fig_width, 6.5))
+
+    bp = ax.boxplot(
+        series,
+        positions=positions,
+        widths=width,
+        patch_artist=True,
+        showfliers=True,
+        whis=(1, 99),
+    )
+
+    for patch, color in zip(bp["boxes"], colors):
+        patch.set_facecolor(color)
+        patch.set_alpha(0.85)
+
+    for median in bp["medians"]:
+        median.set_color("black")
+        median.set_linewidth(1.4)
+
+    if truth_x:
+        ax.scatter(
+            truth_x,
+            truth_y,
+            color="green",
+            edgecolors="black",
+            marker="o",
+            s=70,
+            zorder=4,
+            label="Ground truth",
+        )
+
+    legend_handles = [
+        plt.Line2D([0], [0], color="#4C72B0", lw=8, label="mp"),
+        plt.Line2D([0], [0], color="#DD8452", lw=8, label="nomp"),
+    ]
+    if truth_x:
+        legend_handles.append(
+            plt.Line2D(
+                [0],
+                [0],
+                marker="o",
+                color="w",
+                markerfacecolor="green",
+                markeredgecolor="black",
+                markersize=8,
+                linestyle="None",
+                label="Ground truth",
+            )
+        )
+    ax.legend(handles=legend_handles)
+
+    ax.set_xticks(tick_positions)
+    ax.set_xticklabels(tick_labels)
+    ax.set_xlabel("Number of loops")
+    ax.set_ylabel("Metric Value")
+    if logscale:
+        ax.set_yscale("log")
+    ax.set_title(f"Metric Distribution for {metric_name} ({bench_type})")
+    ax.grid(axis="y", linestyle="--", alpha=0.4)
+
+    fig.tight_layout()
+    fig.savefig(output_path)
+    plt.close(fig)
+
+    print(f"Plot saved to {output_path}")
+
+
+def main():
+    args = parse_args()
+
+    data_dir = Path(args.data_dir)
+    if not data_dir.is_dir():
+        raise FileNotFoundError(f"Data directory not found: {data_dir}")
+
+    metric_name = normalize_metric_name(args.metric)
+
+    output_path = (
+        Path(args.output)
+        if args.output
+        else Path(f"metric_{args.type}_{metric_name}.png")
+    )
+
+    grouped_data = collect_data(data_dir, args.type, metric_name)
+    plot_grouped_boxplots(
+        grouped_data,
+        metric_name,
+        args.type,
+        output_path,
+        logscale=args.logscale,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/plot_perf_metric.py
+++ b/plot_perf_metric.py
@@ -17,11 +17,15 @@ def normalize_metric_name(metric_name):
     return metric_name.strip().replace("arith_inst_retired_", "")
 
 
+def int_list(values):
+    return [int(value.strip()) for value in values.split(",") if value.strip()] if values else []
+
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description=(
             "Plot paired mp/nomp boxplots for one metric across loop counts "
-            "from perf benchmark output directories."
+            "from perf benchmark output directories, plus a percent-difference plot."
         )
     )
     parser.add_argument(
@@ -44,16 +48,23 @@ def parse_args():
         help="Benchmark type: double or complex",
     )
     parser.add_argument(
+        "-e",
+        "--exclude",
+        type=int_list,
+        default=[],
+        help="Comma-separated loop counts to exclude from the plots (default: none)",
+    )
+    parser.add_argument(
         "-o",
-        "--output",
+        "--output-prefix",
         default=None,
-        help="Output plot path (default: metric_<type>_<metric>.png)",
+        help="Output filename prefix (default: metric_<type>_<metric>)",
     )
     parser.add_argument(
         "-l",
         "--logscale",
         action="store_true",
-        help="Use logarithmic scale for y-axis",
+        help="Use logarithmic scale for the boxplot y-axis",
     )
     return parser.parse_args()
 
@@ -128,7 +139,8 @@ def load_ground_truth_value(csv_path, target_metric):
     return None
 
 
-def collect_data(data_dir, bench_type, target_metric):
+def collect_data(data_dir, bench_type, target_metric, excluded_loops=None):
+    excluded_loops = set(excluded_loops or [])
     grouped = defaultdict(dict)
 
     for subdir in sorted(data_dir.iterdir()):
@@ -142,6 +154,9 @@ def collect_data(data_dir, bench_type, target_metric):
         mode, num_ranks_str, num_loops_str = match.groups()
         num_ranks = int(num_ranks_str)
         num_loops = int(num_loops_str)
+
+        if num_loops in excluded_loops:
+            continue
 
         metrics_path = subdir / f"perf_metrics_{bench_type}.csv"
         truth_path = subdir / f"perf_ground_truth_{bench_type}.csv"
@@ -162,9 +177,18 @@ def collect_data(data_dir, bench_type, target_metric):
         }
 
     if not grouped:
-        raise ValueError(f"No matching perf_* subdirectories found under {data_dir}")
+        raise ValueError(
+            f"No matching perf_* subdirectories found under {data_dir} "
+            f"after excluding loop counts {sorted(excluded_loops)}"
+        )
 
     return dict(sorted(grouped.items()))
+
+
+def mean(values):
+    if not values:
+        return None
+    return sum(values) / len(values)
 
 
 def plot_grouped_boxplots(grouped_data, metric_name, bench_type, output_path, logscale=False):
@@ -180,7 +204,6 @@ def plot_grouped_boxplots(grouped_data, metric_name, bench_type, output_path, lo
 
     width = 0.32
     group_gap = 1.25
-
     current_center = 1.0
 
     for num_loops in loops_sorted:
@@ -287,7 +310,88 @@ def plot_grouped_boxplots(grouped_data, metric_name, bench_type, output_path, lo
     fig.savefig(output_path)
     plt.close(fig)
 
-    print(f"Plot saved to {output_path}")
+    print(f"Boxplot saved to {output_path}")
+
+
+def plot_percent_difference(grouped_data, metric_name, bench_type, output_path):
+    loops_sorted = sorted(grouped_data.keys())
+
+    mp_positions = []
+    mp_values = []
+    nomp_positions = []
+    nomp_values = []
+    tick_positions = []
+    tick_labels = []
+
+    bar_width = 0.32
+    group_gap = 1.25
+    current_center = 1.0
+
+    for num_loops in loops_sorted:
+        group = grouped_data[num_loops]
+        mp_pos = current_center - 0.22
+        nomp_pos = current_center + 0.22
+
+        tick_positions.append(current_center)
+        tick_labels.append(str(num_loops))
+
+        if "mp" in group:
+            gt = group["mp"]["ground_truth"]
+            avg = mean(group["mp"]["values"])
+            if gt not in (None, 0.0) and avg is not None:
+                mp_positions.append(mp_pos)
+                mp_values.append(100.0 * (avg - gt) / gt)
+
+        if "nomp" in group:
+            gt = group["nomp"]["ground_truth"]
+            avg = mean(group["nomp"]["values"])
+            if gt not in (None, 0.0) and avg is not None:
+                nomp_positions.append(nomp_pos)
+                nomp_values.append(100.0 * (avg - gt) / gt)
+
+        current_center += group_gap
+
+    if not mp_values and not nomp_values:
+        raise ValueError(
+            f"No valid percent-difference data found for metric '{metric_name}'"
+        )
+
+    fig_width = max(10, len(loops_sorted) * 1.8)
+    fig, ax = plt.subplots(figsize=(fig_width, 6.5))
+
+    if mp_values:
+        ax.bar(
+            mp_positions,
+            mp_values,
+            width=bar_width,
+            color="#4C72B0",
+            alpha=0.85,
+            label="mp",
+        )
+    if nomp_values:
+        ax.bar(
+            nomp_positions,
+            nomp_values,
+            width=bar_width,
+            color="#DD8452",
+            alpha=0.85,
+            label="nomp",
+        )
+
+    ax.axhline(0.0, color="black", linewidth=1.0)
+    ax.set_xticks(tick_positions)
+    ax.set_xticklabels(tick_labels)
+    ax.set_xlabel("Number of loops")
+    ax.set_ylabel("Percent Difference from Ground Truth (%)")
+    ax.set_title(f"Percent Difference from Ground Truth for {metric_name} ({bench_type})")
+    ax.grid(axis="y", linestyle="--", alpha=0.4)
+    ax.legend()
+
+    fig.tight_layout()
+    fig.savefig(output_path)
+    plt.close(fig)
+
+    print(f"Percent-difference plot saved to {output_path}")
 
 
 def main():
@@ -299,19 +403,30 @@ def main():
 
     metric_name = normalize_metric_name(args.metric)
 
-    output_path = (
-        Path(args.output)
-        if args.output
-        else Path(f"metric_{args.type}_{metric_name}.png")
+    output_prefix = args.output_prefix or f"metric_{args.type}_{metric_name}"
+    boxplot_path = Path(f"{output_prefix}_boxplot.png")
+    pctdiff_path = Path(f"{output_prefix}_pctdiff.png")
+
+    grouped_data = collect_data(
+        data_dir,
+        args.type,
+        metric_name,
+        excluded_loops=args.exclude,
     )
 
-    grouped_data = collect_data(data_dir, args.type, metric_name)
     plot_grouped_boxplots(
         grouped_data,
         metric_name,
         args.type,
-        output_path,
+        boxplot_path,
         logscale=args.logscale,
+    )
+
+    plot_percent_difference(
+        grouped_data,
+        metric_name,
+        args.type,
+        pctdiff_path,
     )
 
 

--- a/src/benchmarks.cc
+++ b/src/benchmarks.cc
@@ -1,0 +1,301 @@
+#include <mpi.h>
+#include <Kokkos_Random.hpp>
+#include <Kokkos_Complex.hpp>
+
+#include "ops.h"
+#include "benchmarks.h"
+
+#include <iostream>
+
+namespace benchmarks {
+
+template <>
+std::string typeToString<double>() {
+    return "double ";
+}
+
+template <>
+std::string typeToString<Kokkos::complex<double>>() {
+    return "complex";
+}
+
+std::string benchmarkToString(const benchmark_types& b) {
+    switch (b) {
+        case level1: return "level1";
+        case level2: return "level2";
+        case level3: return "level3";
+        case dpotrf: return "dpotrf";
+        case perf:   return "perf";
+        default:     return "unknown";
+    }
+}
+
+template <typename T>
+benchmark_results_t runBenchmarkLevel1(int N, int iters) {
+    Kokkos::View<T*> x("x", N);
+    Kokkos::View<T*> y("y", N);
+
+    T* x_ptr = x.data();
+    T* y_ptr = y.data();
+
+    Kokkos::Random_XorShift64_Pool pool(123);
+    Kokkos::fill_random(x, pool, 10.0);
+    Kokkos::fill_random(y, pool, 10.0);
+
+    std::vector<double> iter_timings;
+    double total_time = 0.0;
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    for (int i = 0; i < iters; i++) {
+        Kokkos::Timer timer;
+        ops::level1<T>(N, x_ptr, y_ptr);
+        Kokkos::fence();
+
+        // Skip the first iteration
+        if (i > 0) {
+            double time = timer.seconds();
+            total_time += time;
+            iter_timings.push_back(time);
+        }
+    }
+
+    int rank = -1;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    std::cout << "[level1 " << typeToString<T>() << "] (N=" << N << ") rank: " << rank << ", total_time=" << total_time << std::endl;
+
+    return std::make_tuple(iter_timings, total_time);
+}
+
+template <typename T>
+benchmark_results_t runBenchmarkLevel2(int M, int N, int iters) {
+    Kokkos::View<T*> x("x", M);
+    Kokkos::View<T*> y("y", N);
+    Kokkos::View<T**> A("A", M, N);
+
+    T* x_ptr = x.data();
+    T* y_ptr = y.data();
+    T* A_ptr = A.data();
+
+    Kokkos::Random_XorShift64_Pool pool(123);
+    Kokkos::fill_random(x, pool, 10.0);
+    Kokkos::fill_random(y, pool, 10.0);
+    Kokkos::fill_random(A, pool, 10.0);
+
+    std::vector<double> iter_timings;
+    double total_time = 0.0;
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    for (int i = 0; i < iters; i++) {
+        Kokkos::Timer timer;
+        ops::level2<T>(M, N, T(1.0), x_ptr, y_ptr, A_ptr, N);
+        Kokkos::fence();
+
+        // Skip the first iteration
+        if (i > 0) {
+            double time = timer.seconds();
+            total_time += time;
+            iter_timings.push_back(time);
+        }
+    }
+
+    int rank = -1;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    std::cout << "[level2 " << typeToString<T>() << "] (M=" << M << ", N=" << N << ") rank: " << rank << ", total_time=" << total_time << std::endl;
+
+    return std::make_tuple(iter_timings, total_time);
+}
+
+template <typename T>
+benchmark_results_t runBenchmarkLevel3(int M, int N, int K, int iters) {
+    Kokkos::View<T**> A("A", M, N);
+    Kokkos::View<T**> B("B", N, K);
+    Kokkos::View<T**> C("C", M, K);
+
+    T* A_ptr = A.data();
+    T* B_ptr = B.data();
+    T* C_ptr = C.data();
+
+    Kokkos::Random_XorShift64_Pool pool(123);
+    Kokkos::fill_random(A, pool, 10.0);
+    Kokkos::fill_random(B, pool, 10.0);
+    Kokkos::fill_random(C, pool, 10.0);
+
+    std::vector<double> iter_timings;
+
+    double total_time = 0.0;
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    for (int i = 0; i < iters; i++) {
+        Kokkos::Timer timer;
+        ops::level3<T>(M, K, N, T(1.0), A_ptr, N, B_ptr, K, T(0.0), C_ptr, K);
+        Kokkos::fence();
+
+        // Skip the first iteration
+        if (i > 0) {
+            double time = timer.seconds();
+            total_time += time;
+            iter_timings.push_back(time);
+        }
+    }
+
+    int rank = -1;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    std::cout << "[level3 " << typeToString<T>() << "] (M=" << M << ", N=" << N << ", K=" << K << ") rank: " << rank << ", total_time=" << total_time << std::endl;
+
+    return std::make_tuple(iter_timings, total_time);
+}
+
+template <typename T>
+benchmark_results_t runBenchmarkDPOTRF(int N, int iters) {
+    Kokkos::View<T**> A("A", N, N);
+
+    Kokkos::Random_XorShift64_Pool pool(123);
+    Kokkos::fill_random(A, pool, 10.0);
+
+    // Make A symmetric positive definite
+    Kokkos::parallel_for("MakeSPD", N, KOKKOS_LAMBDA(int i) {
+        for (int j = 0; j < N; j++) {
+            A(i, j) = A(i, j) + A(j, i);
+        }
+    });
+
+    Kokkos::fence();
+
+    T* A_ptr = A.data();
+
+    std::vector<double> iter_timings;
+    double total_time = 0.0;
+
+    long long N_ll = static_cast<long long>(N);
+    char uplo = 'L';
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    for (int i = 0; i < iters; i++) {
+        long long info;
+        Kokkos::Timer timer;
+        ops::dpotrf<T>(uplo, N_ll, A_ptr, N_ll, &info);
+
+        Kokkos::fence();
+
+        // Skip the first iteration
+        if (i > 0) {
+            double time = timer.seconds();
+            total_time += time;
+            iter_timings.push_back(time);
+        }
+    }
+
+    int rank = -1;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    std::cout << "[dpotrf " << typeToString<T>() << "] (N=" << N << ") rank: " << rank << ", total_time=" << total_time << std::endl;
+
+    return std::make_tuple(iter_timings, total_time);
+}
+
+template <typename T>
+benchmark_results_t runBenchmark(benchmark_types b, std::vector<int> sizes, int iters) {
+    switch (b) {
+        case level1:
+            return runBenchmarkLevel1<T>(sizes[0], iters);
+        case level2:
+            return runBenchmarkLevel2<T>(sizes[1], sizes[2], iters);
+        case level3:
+            return runBenchmarkLevel3<T>(sizes[3], sizes[4], sizes[5], iters);
+        case dpotrf:
+            return runBenchmarkDPOTRF<T>(sizes[6], iters);
+        case perf:
+            return runBenchmarkPerf<T>(iters);
+        default:
+            throw std::invalid_argument("Unsupported benchmark type");
+    }
+}
+
+all_results_t runSelectedBenchmark(benchmark_types b, std::vector<int> sizes, int iters) {
+    all_results_t results;
+    std::string benchmark_str = benchmarkToString(b);
+    results[benchmark_str + "_double"] = runBenchmark<double>(b, sizes, iters);
+    MPI_Barrier(MPI_COMM_WORLD);
+    results[benchmark_str + "_complex"] = runBenchmark<Kokkos::complex<double>>(b, sizes, iters);
+    MPI_Barrier(MPI_COMM_WORLD);
+    return results;
+}
+
+all_results_t runAllBenchmarks(std::vector<int> sizes, int iters) {
+    all_results_t all_results;
+    for (int i=0; i < benchmark_types::num_benchmarks; i++) {
+        auto b = static_cast<benchmark_types>(i);
+        all_results.merge(runSelectedBenchmark(b, sizes, iters));
+    }
+    return all_results;
+}
+
+void printBenchmarkOutput(all_results_t benchmark_results, int iters)
+{
+    int rank = -1;
+    int num_ranks = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &num_ranks);
+
+    if (rank == 0) {
+        std::cout << "num_ranks: " << num_ranks << std::endl;
+    }
+
+    for (const auto& [benchmark_str, benchmark_results]: benchmark_results) {
+        char processor_name[MPI_MAX_PROCESSOR_NAME];
+        int name_len;
+        MPI_Get_processor_name(processor_name, &name_len);
+
+        auto const& [iter_timings, total_time] = benchmark_results;
+
+        std::vector<double> all_times;
+        all_times.resize(num_ranks);
+
+        std::vector<double> all_iter_times;
+        all_iter_times.resize(num_ranks * iters);
+
+        std::vector<char> all_processor_names;
+        all_processor_names.resize(num_ranks * MPI_MAX_PROCESSOR_NAME);
+
+        MPI_Gather(
+            &total_time, 1, MPI_DOUBLE,
+            &all_times[0], 1, MPI_DOUBLE, 0,
+            MPI_COMM_WORLD
+        );
+
+        MPI_Gather(
+            &iter_timings[0], iters, MPI_DOUBLE,
+            &all_iter_times[0], iters, MPI_DOUBLE, 0,
+            MPI_COMM_WORLD
+        );
+
+        MPI_Gather(
+            &processor_name, MPI_MAX_PROCESSOR_NAME, MPI_CHAR,
+            &all_processor_names[0], MPI_MAX_PROCESSOR_NAME, MPI_CHAR, 0,
+            MPI_COMM_WORLD
+        );
+
+        if (rank == 0) {
+            int cur_rank = 0;
+            int cur = 0;
+            std::cout << std::endl << benchmark_str << std::endl;
+            for (auto&& time : all_times) {
+                std::cout << "gather: " << cur_rank << " ("
+                    << std::string(&all_processor_names[cur_rank * MPI_MAX_PROCESSOR_NAME])
+                    << "): " << time << ": breakdown: ";
+                for (int i = cur; i < iters + cur; i++) {
+                    std::cout << all_iter_times[i] << " ";
+                }
+                std::cout << std::endl;
+                cur += iters;
+                cur_rank++;
+            }
+        }
+    }
+}
+} // end namespace benchmarks

--- a/src/benchmarks.h
+++ b/src/benchmarks.h
@@ -1,0 +1,54 @@
+#ifndef SRC_BENCHMARKS_H
+#define SRC_BENCHMARKS_H
+
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+namespace benchmarks {
+
+using benchmark_results_t = std::tuple<std::vector<double>, double>;
+using all_results_t = std::unordered_map<std::string, benchmark_results_t>;
+
+enum benchmark_types {
+    level1,
+    level2,
+    level3,
+    dpotrf,
+    perf,
+    num_benchmarks
+};
+
+template <typename T>
+std::string typeToString();
+
+std::string benchmarkToString(const benchmark_types& b);
+
+template <typename T>
+benchmark_results_t runBenchmarkLevel1(int N, int iters);
+
+template <typename T>
+benchmark_results_t runBenchmarkLevel2(int M, int N, int iters);
+
+template <typename T>
+benchmark_results_t runBenchmarkLevel3(int M, int N, int K, int iters);
+
+template <typename T>
+benchmark_results_t runBenchmarkDPOTRF(int N, int iters);
+
+template <typename T>
+benchmark_results_t runBenchmarkPerf(int iters);
+
+template <typename T>
+benchmark_results_t runBenchmark(benchmark_types b, std::vector<int> sizes, int iters);
+
+all_results_t runSelectedBenchmark(benchmark_types b, std::vector<int> sizes, int iters);
+
+all_results_t runAllBenchmarks(std::vector<int> sizes, int iters);
+
+void printBenchmarkOutput(all_results_t benchmark_results, int iters);
+
+} // end namespace benchmarks
+
+#endif // SRC_BENCHMARKS_H

--- a/src/ops.h
+++ b/src/ops.h
@@ -1,0 +1,32 @@
+#ifndef SRC_OPS_H
+#define SRC_OPS_H
+
+namespace ops {
+
+template <typename T>
+constexpr bool isDouble();
+
+template <typename T>
+constexpr bool isComplex();
+
+template <typename T>
+void level1(int N, const T* x, const T* y);
+
+template <typename T>
+void level2(int M, int N, T alpha, const T* x, const T* y, T* A, int lda);
+
+template <typename T>
+void level3(
+    int M, int N, int K,
+    T alpha, const T* A, int lda,
+    const T* B, int ldb,
+    T beta,  T* C, int ldc);
+
+template <typename T>
+void dpotrf(char uplo, long long n, T* a, long long lda, long long* info);
+
+} // end namespace ops
+
+#include "ops_impl.h"
+
+#endif // SRC_OPS_H

--- a/src/ops_impl.h
+++ b/src/ops_impl.h
@@ -1,0 +1,165 @@
+#ifndef SRC_OPS_IMPL_H
+#define SRC_OPS_IMPL_H
+
+#include <mkl.h>
+#include <cassert>
+#include <iostream>
+
+#include <Kokkos_Complex.hpp>
+
+#include "ops.h"
+#include "benchmarks.h"
+
+namespace ops {
+
+///////////////////////////////////////////////////////////////////////////////
+// Helpers
+
+template <typename T>
+constexpr bool isComplex() {
+    if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
+        return true;
+    }
+    return false;
+}
+
+template <typename T>
+constexpr bool isDouble() {
+    if constexpr (std::is_same_v<T, double>) {
+        return true;
+    }
+    assert(isComplex<T>() && "Type must be either double or Kokkos::complex<double>.");
+    return false;
+}
+
+static void warnWrongType(const std::string& benchmark) {
+    std::cout << "Warning: Type must be either double or Kokkos::complex. Skipping " << benchmark << " benchmark." << std::endl;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// LEVEL 1
+
+template <typename T>
+void level1(int N, const T* x, const T* y) {
+    if constexpr (isDouble<T>()) {
+        cblas_ddot(N, x, 1, y, 1);
+    } else if constexpr (isComplex<T>()) {
+        T result;
+        cblas_zdotu_sub(N, x, 1, y, 1, &result);
+    } else {
+        warnWrongType("level1");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// LEVEL 2
+
+template <typename T>
+void level2(
+    int M,
+    int N,
+    T alpha,
+    const T* x,
+    const T* y,
+    T* A,
+    int lda)
+{
+    if constexpr (isDouble<T>()) {
+        cblas_dger(CblasRowMajor, M, N, alpha, x, 1, y, 1, A, lda);
+    } else if constexpr (isComplex<T>()) {
+        cblas_zgeru(
+            CblasRowMajor,
+            M, N,
+            reinterpret_cast<const void*>(&alpha),
+            reinterpret_cast<const void*>(x), 1,
+            reinterpret_cast<const void*>(y), 1,
+            reinterpret_cast<void*>(A), lda
+        );
+    } else {
+        warnWrongType("level2");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// LEVEL 3
+
+template <typename T>
+void level3(
+    int M,
+    int N,
+    int K,
+    T alpha,
+    const T* A,
+    int lda,
+    const T* B,
+    int ldb,
+    T beta,
+    T* C,
+    int ldc)
+{
+    if constexpr (isDouble<T>()) {
+        cblas_dgemm(
+            CblasRowMajor, CblasNoTrans, CblasNoTrans,
+            M, N, K,
+            alpha,
+            A, lda,
+            B, ldb,
+            beta,
+            C, ldc
+        );
+    } else if constexpr (isComplex<T>()) {
+        cblas_zgemm(
+            CblasRowMajor, CblasNoTrans, CblasNoTrans,
+            M, N, K,
+            reinterpret_cast<const void*>(&alpha),
+            reinterpret_cast<const void*>(A), lda,
+            reinterpret_cast<const void*>(B), ldb,
+            reinterpret_cast<const void*>(&beta),
+            reinterpret_cast<void*>(C), ldc);
+    } else {
+        warnWrongType("level3");
+    }
+
+
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// DPOTRF
+
+template <typename T>
+void dpotrf(char uplo, long long n, T* a, long long lda, long long* info) {
+        long long local_info = 0;
+
+    if constexpr (isDouble<T>()) {
+                local_info = static_cast<long long>(
+                    LAPACKE_dpotrf(
+                        LAPACK_ROW_MAJOR,
+                        uplo,
+                        static_cast<lapack_int>(n),
+                        a,
+                        static_cast<lapack_int>(lda)
+                    )
+                );
+    } else if constexpr (isComplex<T>()) {
+                local_info = static_cast<long long>(
+                    LAPACKE_zpotrf(
+                        LAPACK_ROW_MAJOR,
+                        uplo,
+                        static_cast<lapack_int>(n),
+                        reinterpret_cast<MKL_Complex16*>(a),
+                        static_cast<lapack_int>(lda)
+                    )
+                );
+    } else {
+                local_info = -1;
+        warnWrongType("dpotrf");
+    }
+
+        if (info != nullptr) {
+                *info = local_info;
+        }
+}
+
+} // end namespace ops
+
+#endif // SRC_OPS_IMPL_H

--- a/src/perf.cc
+++ b/src/perf.cc
@@ -1,0 +1,125 @@
+#ifdef VT_ENABLED
+#include <vt/transport.h>
+#endif
+
+#ifndef vt_check_enabled
+#define vt_check_enabled(test_option) 0
+#endif
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <mpi.h>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace perf {
+
+namespace {
+
+std::string sanitizeBenchmarkName(std::string benchmark_name) {
+    if (benchmark_name.empty()) {
+        return "perf";
+    }
+
+    for (char& ch : benchmark_name) {
+        if (!std::isalnum(static_cast<unsigned char>(ch)) && ch != '_' && ch != '-') {
+            ch = '_';
+        }
+    }
+
+    return benchmark_name;
+}
+
+} // namespace
+
+void startMeasurements() {
+#if vt_check_enabled( perf )
+    vt::theContext()->getTask()->startMetrics();
+#endif
+}
+
+void stopMeasurements(const std::string& benchmark_name) {
+#if vt_check_enabled( perf )
+    vt::theContext()->getTask()->stopMetrics();
+
+    int rank = 0;
+    int size = 1;
+    char processor_name[MPI_MAX_PROCESSOR_NAME];
+    int name_len = 0;
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Get_processor_name(processor_name, &name_len);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    std::unordered_map< std::string, uint64_t > metrics = vt::theContext()->getTask()->getMetrics();
+
+    std::vector<std::pair<std::string, uint64_t>> ordered_metrics(metrics.begin(), metrics.end());
+    std::sort(
+      ordered_metrics.begin(),
+      ordered_metrics.end(),
+      [](const auto& a, const auto& b) { return a.first < b.first; }
+    );
+
+    std::ostringstream local_csv;
+    for (const auto& [name, value] : ordered_metrics) {
+        local_csv << rank << "," << processor_name << "," << name << "," << value << "\n";
+    }
+
+    const std::string local_payload = local_csv.str();
+    const int local_bytes = static_cast<int>(local_payload.size());
+
+    std::vector<int> recv_counts;
+    if (rank == 0) {
+        recv_counts.resize(size);
+    }
+
+    MPI_Gather(
+      &local_bytes,
+      1,
+      MPI_INT,
+      rank == 0 ? recv_counts.data() : nullptr,
+      1,
+      MPI_INT,
+      0,
+      MPI_COMM_WORLD
+    );
+
+    std::vector<int> displacements;
+    std::vector<char> gathered_payload;
+    if (rank == 0) {
+        displacements.resize(size, 0);
+        int total_bytes = 0;
+        for (int i = 0; i < size; ++i) {
+            displacements[i] = total_bytes;
+            total_bytes += recv_counts[i];
+        }
+        gathered_payload.resize(total_bytes);
+    }
+
+    MPI_Gatherv(
+      local_payload.data(),
+      local_bytes,
+      MPI_CHAR,
+      rank == 0 ? gathered_payload.data() : nullptr,
+      rank == 0 ? recv_counts.data() : nullptr,
+      rank == 0 ? displacements.data() : nullptr,
+      MPI_CHAR,
+      0,
+      MPI_COMM_WORLD
+    );
+
+    if (rank == 0) {
+        std::string const output_name = "perf_metrics_" + sanitizeBenchmarkName(benchmark_name) + ".csv";
+        std::ofstream out(output_name, std::ios::out | std::ios::trunc);
+        out << "rank,hostname,metric,value\n";
+        out.write(gathered_payload.data(), static_cast<std::streamsize>(gathered_payload.size()));
+    }
+#endif
+}
+
+} // namespace perf

--- a/src/perf.h
+++ b/src/perf.h
@@ -1,0 +1,8 @@
+
+
+#include <string>
+
+namespace perf {
+  void startMeasurements();
+  void stopMeasurements(const std::string& benchmark_name);
+}

--- a/src/perf_benchmark.cc
+++ b/src/perf_benchmark.cc
@@ -1,0 +1,516 @@
+#include <mpi.h>
+#include <Kokkos_Complex.hpp>
+#include <Kokkos_Core.hpp>
+
+#include "benchmarks.h"
+#include "perf.h"
+
+#include <array>
+#include <iostream>
+#include <type_traits>
+#include <vector>
+
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
+#include <immintrin.h>
+#define SLOW_NODE_X86_SIMD 1
+#else
+#define SLOW_NODE_X86_SIMD 0
+#endif
+
+namespace benchmarks {
+
+namespace {
+
+constexpr int kPerfWarmupIters = 1;
+constexpr int kPerfLoopCount = 512;
+constexpr int kPerfVectorLength = 256;
+
+template <typename T>
+inline void doNotOptimize(T const& value) {
+#if defined(__GNUC__) || defined(__clang__)
+    asm volatile("" : : "g"(value) : "memory");
+#else
+    (void)value;
+#endif
+}
+
+inline int perfLoopCount() {
+    return kPerfLoopCount;
+}
+
+#if SLOW_NODE_X86_SIMD && (defined(__GNUC__) || defined(__clang__))
+
+struct SimdCapabilities {
+    bool sse2 = false;
+    bool avx = false;
+    bool avx2_fma = false;
+    bool avx512f = false;
+};
+
+SimdCapabilities detectSimdCapabilities() {
+    __builtin_cpu_init();
+
+    SimdCapabilities capabilities;
+    capabilities.sse2 = __builtin_cpu_supports("sse2");
+    capabilities.avx = __builtin_cpu_supports("avx");
+    capabilities.avx2_fma = __builtin_cpu_supports("avx2") && __builtin_cpu_supports("fma");
+    capabilities.avx512f = __builtin_cpu_supports("avx512f");
+    return capabilities;
+}
+
+__attribute__((target("sse2"), noinline))
+double runSseScalarKernel(
+  double* lhs, double* rhs, double* out,
+  float* lhs_f, float* rhs_f, float* out_f,
+  int count, int loops
+) {
+    // Primarily drives:
+    // - fp_arith_inst_retired_scalar_double
+    // - fp_arith_inst_retired_scalar_single
+    __m128d accum_d = _mm_set_sd(0.25);
+    __m128 accum_f = _mm_set_ss(0.5f);
+    __m128d damp_d = _mm_set_sd(0.99999988079071044921875);
+    __m128 damp_f = _mm_set_ss(0.99999988f);
+
+    for (int loop = 0; loop < loops; ++loop) {
+        for (int i = 0; i < count; ++i) {
+            __m128d lhs_d = _mm_load_sd(lhs + i);
+            __m128d rhs_d = _mm_load_sd(rhs + i);
+            __m128 lhs_s = _mm_load_ss(lhs_f + i);
+            __m128 rhs_s = _mm_load_ss(rhs_f + i);
+
+            accum_d = _mm_add_sd(_mm_mul_sd(accum_d, damp_d), _mm_mul_sd(lhs_d, rhs_d));
+            accum_f = _mm_add_ss(_mm_mul_ss(accum_f, damp_f), _mm_mul_ss(lhs_s, rhs_s));
+
+            _mm_store_sd(out + i, accum_d);
+            _mm_store_ss(out_f + i, accum_f);
+        }
+    }
+
+    return _mm_cvtsd_f64(accum_d) + static_cast<double>(_mm_cvtss_f32(accum_f))
+      + out[count - 1] + static_cast<double>(out_f[count - 1]);
+}
+
+__attribute__((target("sse2"), noinline))
+double runSsePackedKernel(
+  double* lhs, double* rhs, double* out,
+  float* lhs_f, float* rhs_f, float* out_f,
+  int count, int loops
+) {
+    // Primarily drives:
+    // - fp_arith_inst_retired_128b_packed_double
+    // - fp_arith_inst_retired_128b_packed_single
+    __m128d accum0 = _mm_set1_pd(0.25);
+    __m128d accum1 = _mm_set1_pd(0.75);
+    __m128 accum_f = _mm_set1_ps(0.5f);
+    __m128d scale_a = _mm_set1_pd(1.00000011920928955078125);
+    __m128d scale_b = _mm_set1_pd(0.9999997615814208984375);
+    __m128 scale_f = _mm_set1_ps(1.0000001f);
+
+    for (int loop = 0; loop < loops; ++loop) {
+        for (int i = 0; i < count; i += 4) {
+            __m128d lhs0 = _mm_loadu_pd(lhs + i);
+            __m128d rhs0 = _mm_loadu_pd(rhs + i);
+            __m128d lhs1 = _mm_loadu_pd(lhs + i + 2);
+            __m128d rhs1 = _mm_loadu_pd(rhs + i + 2);
+            __m128 lhs_s = _mm_loadu_ps(lhs_f + i);
+            __m128 rhs_s = _mm_loadu_ps(rhs_f + i);
+
+            __m128d mix0 = _mm_add_pd(_mm_mul_pd(lhs0, scale_a), rhs0);
+            __m128d mix1 = _mm_sub_pd(_mm_mul_pd(lhs1, scale_b), rhs1);
+            __m128 mix_s = _mm_add_ps(_mm_mul_ps(lhs_s, scale_f), rhs_s);
+
+            accum0 = _mm_add_pd(accum0, _mm_mul_pd(mix0, mix0));
+            accum1 = _mm_add_pd(accum1, _mm_mul_pd(mix1, mix1));
+            accum_f = _mm_add_ps(accum_f, _mm_mul_ps(mix_s, mix_s));
+
+            _mm_storeu_pd(out + i, _mm_add_pd(mix0, accum0));
+            _mm_storeu_pd(out + i + 2, _mm_sub_pd(mix1, accum1));
+            _mm_storeu_ps(out_f + i, _mm_add_ps(mix_s, accum_f));
+        }
+    }
+
+    alignas(16) std::array<double, 2> lane0{};
+    alignas(16) std::array<double, 2> lane1{};
+    alignas(16) std::array<float, 4> lanes_f{};
+    _mm_store_pd(lane0.data(), accum0);
+    _mm_store_pd(lane1.data(), accum1);
+    _mm_store_ps(lanes_f.data(), accum_f);
+    return lane0[0] + lane0[1] + lane1[0] + lane1[1]
+      + lanes_f[0] + lanes_f[1] + lanes_f[2] + lanes_f[3]
+      + out[count - 1] + static_cast<double>(out_f[count - 1]);
+}
+
+__attribute__((target("avx"), noinline))
+double runAvxKernel(double* lhs, double* rhs, double* out, int count, int loops) {
+    // Primarily drives:
+    // - fp_arith_inst_retired_256b_packed_double
+    __m256d accum0 = _mm256_set1_pd(0.5);
+    __m256d accum1 = _mm256_set1_pd(1.5);
+    __m256d bias = _mm256_setr_pd(1.0, -1.0, 0.5, -0.5);
+    __m256d scale = _mm256_set1_pd(1.0000002384185791015625);
+
+    for (int loop = 0; loop < loops; ++loop) {
+        for (int i = 0; i < count; i += 8) {
+            __m256d lhs0 = _mm256_loadu_pd(lhs + i);
+            __m256d rhs0 = _mm256_loadu_pd(rhs + i);
+            __m256d lhs1 = _mm256_loadu_pd(lhs + i + 4);
+            __m256d rhs1 = _mm256_loadu_pd(rhs + i + 4);
+
+            __m256d mix0 = _mm256_add_pd(_mm256_mul_pd(lhs0, scale), _mm256_add_pd(rhs0, bias));
+            __m256d mix1 = _mm256_sub_pd(_mm256_mul_pd(rhs1, scale), _mm256_sub_pd(lhs1, bias));
+
+            accum0 = _mm256_add_pd(accum0, _mm256_mul_pd(mix0, mix0));
+            accum1 = _mm256_add_pd(accum1, _mm256_mul_pd(mix1, mix1));
+
+            _mm256_storeu_pd(out + i, _mm256_add_pd(mix0, accum0));
+            _mm256_storeu_pd(out + i + 4, _mm256_sub_pd(mix1, accum1));
+        }
+    }
+
+    alignas(32) std::array<double, 4> lanes0{};
+    alignas(32) std::array<double, 4> lanes1{};
+    _mm256_store_pd(lanes0.data(), accum0);
+    _mm256_store_pd(lanes1.data(), accum1);
+    return lanes0[0] + lanes0[1] + lanes0[2] + lanes0[3]
+      + lanes1[0] + lanes1[1] + lanes1[2] + lanes1[3] + out[count - 2];
+}
+
+__attribute__((target("avx"), noinline))
+double runAvxSingleKernel(float* lhs, float* rhs, float* out, int count, int loops) {
+    // Primarily drives:
+    // - fp_arith_inst_retired_256b_packed_single
+    __m256 accum0 = _mm256_set1_ps(0.5f);
+    __m256 accum1 = _mm256_set1_ps(1.5f);
+    __m256 bias = _mm256_setr_ps(1.0f, -1.0f, 0.5f, -0.5f, 2.0f, -2.0f, 3.0f, -3.0f);
+    __m256 scale = _mm256_set1_ps(1.0000002f);
+
+    for (int loop = 0; loop < loops; ++loop) {
+        for (int i = 0; i < count; i += 16) {
+            __m256 lhs0 = _mm256_loadu_ps(lhs + i);
+            __m256 rhs0 = _mm256_loadu_ps(rhs + i);
+            __m256 lhs1 = _mm256_loadu_ps(lhs + i + 8);
+            __m256 rhs1 = _mm256_loadu_ps(rhs + i + 8);
+
+            __m256 mix0 = _mm256_add_ps(_mm256_mul_ps(lhs0, scale), _mm256_add_ps(rhs0, bias));
+            __m256 mix1 = _mm256_sub_ps(_mm256_mul_ps(rhs1, scale), _mm256_sub_ps(lhs1, bias));
+
+            accum0 = _mm256_add_ps(accum0, _mm256_mul_ps(mix0, mix0));
+            accum1 = _mm256_add_ps(accum1, _mm256_mul_ps(mix1, mix1));
+
+            _mm256_storeu_ps(out + i, _mm256_add_ps(mix0, accum0));
+            _mm256_storeu_ps(out + i + 8, _mm256_sub_ps(mix1, accum1));
+        }
+    }
+
+    alignas(32) std::array<float, 8> lanes0{};
+    alignas(32) std::array<float, 8> lanes1{};
+    _mm256_store_ps(lanes0.data(), accum0);
+    _mm256_store_ps(lanes1.data(), accum1);
+    double sum = static_cast<double>(out[count - 2]);
+    for (float value : lanes0) {
+        sum += value;
+    }
+    for (float value : lanes1) {
+        sum += value;
+    }
+    return sum;
+}
+
+__attribute__((target("avx"), noinline))
+double runAvxComplexKernel(double* lhs, double* rhs, double* out, int count, int loops) {
+    // Primarily drives:
+    // - fp_arith_inst_retired_256b_packed_double
+    // This path is only used for complex<double> runs.
+    __m256d accum = _mm256_setr_pd(0.125, -0.125, 0.25, -0.25);
+
+    for (int loop = 0; loop < loops; ++loop) {
+        for (int i = 0; i < count; i += 4) {
+            __m256d lhs_vec = _mm256_loadu_pd(lhs + i);
+            __m256d rhs_vec = _mm256_loadu_pd(rhs + i);
+            __m256d lhs_real = _mm256_movedup_pd(lhs_vec);
+            __m256d lhs_imag = _mm256_permute_pd(lhs_vec, 0xF);
+            __m256d rhs_swapped = _mm256_permute_pd(rhs_vec, 0x5);
+
+            __m256d prod0 = _mm256_mul_pd(lhs_real, rhs_vec);
+            __m256d prod1 = _mm256_mul_pd(lhs_imag, rhs_swapped);
+            __m256d complex_value = _mm256_addsub_pd(prod0, prod1);
+
+            accum = _mm256_add_pd(accum, complex_value);
+            _mm256_storeu_pd(out + i, _mm256_add_pd(complex_value, accum));
+        }
+    }
+
+    alignas(32) std::array<double, 4> lanes{};
+    _mm256_store_pd(lanes.data(), accum);
+    return lanes[0] + lanes[1] + lanes[2] + lanes[3] + out[count - 1];
+}
+
+__attribute__((target("avx2,fma"), noinline))
+double runAvx2FmaKernel(double* lhs, double* rhs, double* out, int count, int loops) {
+    // Primarily drives:
+    // - fp_arith_inst_retired_256b_packed_double
+    // Uses FMA instructions; counts are still reflected in retired FP arithmetic events.
+    __m256d accum = _mm256_set1_pd(0.125);
+    __m256d shift = _mm256_setr_pd(0.25, 0.5, 0.75, 1.0);
+
+    for (int loop = 0; loop < loops; ++loop) {
+        for (int i = 0; i < count; i += 8) {
+            __m256d lhs0 = _mm256_loadu_pd(lhs + i);
+            __m256d rhs0 = _mm256_loadu_pd(rhs + i);
+            __m256d lhs1 = _mm256_loadu_pd(lhs + i + 4);
+            __m256d rhs1 = _mm256_loadu_pd(rhs + i + 4);
+
+            __m256d fused0 = _mm256_fmadd_pd(lhs0, rhs0, shift);
+            __m256d fused1 = _mm256_fnmadd_pd(lhs1, rhs1, shift);
+
+            accum = _mm256_add_pd(accum, _mm256_add_pd(fused0, fused1));
+
+            _mm256_storeu_pd(out + i, _mm256_add_pd(fused0, accum));
+            _mm256_storeu_pd(out + i + 4, _mm256_sub_pd(fused1, accum));
+        }
+    }
+
+    alignas(32) std::array<double, 4> lanes{};
+    _mm256_store_pd(lanes.data(), accum);
+    return lanes[0] + lanes[1] + lanes[2] + lanes[3] + out[count - 3];
+}
+
+__attribute__((target("avx2,fma"), noinline))
+double runAvx2FmaSingleKernel(float* lhs, float* rhs, float* out, int count, int loops) {
+    // Primarily drives:
+    // - fp_arith_inst_retired_256b_packed_single
+    // Uses FMA instructions; counts are still reflected in retired FP arithmetic events.
+    __m256 accum = _mm256_set1_ps(0.125f);
+    __m256 shift = _mm256_setr_ps(0.25f, 0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f);
+
+    for (int loop = 0; loop < loops; ++loop) {
+        for (int i = 0; i < count; i += 16) {
+            __m256 lhs0 = _mm256_loadu_ps(lhs + i);
+            __m256 rhs0 = _mm256_loadu_ps(rhs + i);
+            __m256 lhs1 = _mm256_loadu_ps(lhs + i + 8);
+            __m256 rhs1 = _mm256_loadu_ps(rhs + i + 8);
+
+            __m256 fused0 = _mm256_fmadd_ps(lhs0, rhs0, shift);
+            __m256 fused1 = _mm256_fnmadd_ps(lhs1, rhs1, shift);
+
+            accum = _mm256_add_ps(accum, _mm256_add_ps(fused0, fused1));
+
+            _mm256_storeu_ps(out + i, _mm256_add_ps(fused0, accum));
+            _mm256_storeu_ps(out + i + 8, _mm256_sub_ps(fused1, accum));
+        }
+    }
+
+    alignas(32) std::array<float, 8> lanes{};
+    _mm256_store_ps(lanes.data(), accum);
+    double sum = static_cast<double>(out[count - 3]);
+    for (float value : lanes) {
+        sum += value;
+    }
+    return sum;
+}
+
+__attribute__((target("avx512f"), noinline))
+double runAvx512Kernel(double* lhs, double* rhs, double* out, int count, int loops) {
+    // Primarily drives:
+    // - fp_arith_inst_retired_512b_packed_double
+    __m512d accum = _mm512_set1_pd(0.0625);
+    __m512d blend = _mm512_setr_pd(1.0, -1.0, 2.0, -2.0, 3.0, -3.0, 4.0, -4.0);
+
+    for (int loop = 0; loop < loops; ++loop) {
+        for (int i = 0; i < count; i += 16) {
+            __m512d lhs0 = _mm512_loadu_pd(lhs + i);
+            __m512d rhs0 = _mm512_loadu_pd(rhs + i);
+            __m512d lhs1 = _mm512_loadu_pd(lhs + i + 8);
+            __m512d rhs1 = _mm512_loadu_pd(rhs + i + 8);
+
+            __m512d mix0 = _mm512_add_pd(_mm512_mul_pd(lhs0, rhs0), blend);
+            __m512d mix1 = _mm512_sub_pd(_mm512_mul_pd(lhs1, rhs1), blend);
+
+            accum = _mm512_add_pd(accum, _mm512_add_pd(mix0, mix1));
+
+            _mm512_storeu_pd(out + i, _mm512_add_pd(mix0, accum));
+            _mm512_storeu_pd(out + i + 8, _mm512_sub_pd(mix1, accum));
+        }
+    }
+
+    alignas(64) std::array<double, 8> lanes{};
+    _mm512_store_pd(lanes.data(), accum);
+    return lanes[0] + lanes[1] + lanes[2] + lanes[3]
+      + lanes[4] + lanes[5] + lanes[6] + lanes[7] + out[count - 4];
+}
+
+__attribute__((target("avx512f"), noinline))
+double runAvx512SingleKernel(float* lhs, float* rhs, float* out, int count, int loops) {
+    // Primarily drives:
+    // - fp_arith_inst_retired_512b_packed_single
+    __m512 accum = _mm512_set1_ps(0.0625f);
+    __m512 blend = _mm512_setr_ps(
+      1.0f, -1.0f, 2.0f, -2.0f, 3.0f, -3.0f, 4.0f, -4.0f,
+      5.0f, -5.0f, 6.0f, -6.0f, 7.0f, -7.0f, 8.0f, -8.0f
+    );
+
+    for (int loop = 0; loop < loops; ++loop) {
+        for (int i = 0; i < count; i += 32) {
+            __m512 lhs0 = _mm512_loadu_ps(lhs + i);
+            __m512 rhs0 = _mm512_loadu_ps(rhs + i);
+            __m512 lhs1 = _mm512_loadu_ps(lhs + i + 16);
+            __m512 rhs1 = _mm512_loadu_ps(rhs + i + 16);
+
+            __m512 mix0 = _mm512_add_ps(_mm512_mul_ps(lhs0, rhs0), blend);
+            __m512 mix1 = _mm512_sub_ps(_mm512_mul_ps(lhs1, rhs1), blend);
+
+            accum = _mm512_add_ps(accum, _mm512_add_ps(mix0, mix1));
+
+            _mm512_storeu_ps(out + i, _mm512_add_ps(mix0, accum));
+            _mm512_storeu_ps(out + i + 16, _mm512_sub_ps(mix1, accum));
+        }
+    }
+
+    alignas(64) std::array<float, 16> lanes{};
+    _mm512_store_ps(lanes.data(), accum);
+    double sum = static_cast<double>(out[count - 4]);
+    for (float value : lanes) {
+        sum += value;
+    }
+    return sum;
+}
+
+#endif
+
+double runScalarPerfKernel(double* lhs, double* rhs, double* out, int count, int loops) {
+    // Primarily drives:
+    // - fp_arith_inst_retired_scalar_double
+    // Also contributes to generic events such as instructions/cycles.
+    double accum0 = 0.25;
+    double accum1 = 0.75;
+    double accum2 = -0.5;
+
+    for (int loop = 0; loop < loops; ++loop) {
+        for (int i = 0; i < count; ++i) {
+            double value0 = lhs[i] * rhs[i] + accum0;
+            double value1 = lhs[i] - rhs[i] * accum1;
+            accum2 += (value0 * value0) - (value1 * value1);
+            out[i] = value0 + value1 + accum2;
+            accum0 += value0 * 1.0e-8;
+            accum1 += value1 * 1.0e-8;
+        }
+    }
+
+    return accum0 + accum1 + accum2 + out[count - 1];
+}
+
+template <typename T>
+double runPerfInstructionMix(
+    double* lhs, double* rhs, double* out,
+    float* lhs_f, float* rhs_f, float* out_f
+) {
+    // This intentionally mixes scalar/SSE/AVX/AVX2/FMA/AVX-512 kernels so that
+    // a wide VT_EVENTS list can be exercised in one short benchmark window.
+    // ISA-specific counters remain near zero when that ISA is unavailable.
+    double checksum = 0.0;
+    int const count = kPerfVectorLength;
+    int const loops = perfLoopCount();
+
+    checksum += runScalarPerfKernel(lhs, rhs, out, count, loops / 8);
+
+#if SLOW_NODE_X86_SIMD && (defined(__GNUC__) || defined(__clang__))
+    SimdCapabilities const capabilities = detectSimdCapabilities();
+
+    if (capabilities.sse2) {
+        checksum += runSseScalarKernel(lhs, rhs, out, lhs_f, rhs_f, out_f, count, loops / 8);
+        checksum += runSsePackedKernel(lhs, rhs, out, lhs_f, rhs_f, out_f, count, loops / 8);
+    }
+
+    if (capabilities.avx) {
+        checksum += runAvxKernel(lhs, rhs, out, count, loops / 8);
+        checksum += runAvxSingleKernel(lhs_f, rhs_f, out_f, count, loops / 8);
+        if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
+            checksum += runAvxComplexKernel(lhs, rhs, out, count, loops / 8);
+        }
+    }
+
+    if (capabilities.avx2_fma) {
+        checksum += runAvx2FmaKernel(lhs, rhs, out, count, loops / 8);
+        checksum += runAvx2FmaSingleKernel(lhs_f, rhs_f, out_f, count, loops / 8);
+    }
+
+    if (capabilities.avx512f) {
+        checksum += runAvx512Kernel(lhs, rhs, out, count, loops / 8);
+        checksum += runAvx512SingleKernel(lhs_f, rhs_f, out_f, count, loops / 8);
+    }
+#endif
+
+    return checksum;
+}
+
+template <typename T>
+benchmark_results_t runTimedPerfBenchmark(char const* benchmark_name, int iters) {
+    std::vector<double> lhs(kPerfVectorLength);
+    std::vector<double> rhs(kPerfVectorLength);
+    std::vector<double> out(kPerfVectorLength, 0.0);
+    std::vector<float> lhs_f(kPerfVectorLength);
+    std::vector<float> rhs_f(kPerfVectorLength);
+    std::vector<float> out_f(kPerfVectorLength, 0.0f);
+
+    for (int i = 0; i < kPerfVectorLength; ++i) {
+        lhs[i] = 1.0 + static_cast<double>((i % 17) + 1) * 0.125;
+        rhs[i] = 0.5 + static_cast<double>((i % 11) + 1) * 0.0625;
+        lhs_f[i] = 1.0f + static_cast<float>((i % 13) + 1) * 0.125f;
+        rhs_f[i] = 0.5f + static_cast<float>((i % 7) + 1) * 0.0625f;
+        if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
+            if ((i % 2) == 1) {
+                lhs[i] *= -1.0;
+                rhs[i] *= 0.75;
+                lhs_f[i] *= -1.0f;
+                rhs_f[i] *= 0.75f;
+            }
+        }
+    }
+
+    std::vector<double> iter_timings;
+    iter_timings.reserve(iters > kPerfWarmupIters ? iters - kPerfWarmupIters : 0);
+    double total_time = 0.0;
+    double checksum = 0.0;
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    perf::startMeasurements();
+
+    for (int i = 0; i < iters; ++i) {
+        Kokkos::Timer timer;
+        checksum += runPerfInstructionMix<T>(
+          lhs.data(), rhs.data(), out.data(), lhs_f.data(), rhs_f.data(), out_f.data()
+        );
+
+        if (i >= kPerfWarmupIters) {
+            double const elapsed = timer.seconds();
+            total_time += elapsed;
+            iter_timings.push_back(elapsed);
+        }
+    }
+
+    perf::stopMeasurements(benchmark_name);
+    doNotOptimize(checksum);
+
+    int rank = -1;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    std::cout << "[perf " << benchmark_name << "] rank: " << rank
+              << ", total_time=" << total_time
+              << ", checksum=" << checksum << std::endl;
+
+    return std::make_tuple(iter_timings, total_time);
+}
+
+} // namespace
+
+template <>
+benchmark_results_t runBenchmarkPerf<double>(int iters) {
+    return runTimedPerfBenchmark<double>("double", iters);
+}
+
+template <>
+benchmark_results_t runBenchmarkPerf<Kokkos::complex<double>>(int iters) {
+    return runTimedPerfBenchmark<Kokkos::complex<double>>("complex", iters);
+}
+
+} // namespace benchmarks

--- a/src/perf_benchmark.cc
+++ b/src/perf_benchmark.cc
@@ -6,8 +6,15 @@
 #include "perf.h"
 
 #include <array>
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
 #include <iostream>
+#include <map>
+#include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
@@ -23,7 +30,59 @@ namespace {
 
 constexpr int kPerfWarmupIters = 1;
 constexpr int kPerfLoopCount = 512;
+constexpr int kPerfKernelRepeatCount = kPerfLoopCount / 8;
 constexpr int kPerfVectorLength = 256;
+constexpr std::uint64_t kPerfShuffleSeed = 0x5c37d12f4a9b6e83ULL;
+
+constexpr char const* kMetricScalarDouble = "fp_arith_inst_retired_scalar_double";
+constexpr char const* kMetricScalarSingle = "fp_arith_inst_retired_scalar_single";
+constexpr char const* kMetric128PackedDouble = "fp_arith_inst_retired_128b_packed_double";
+constexpr char const* kMetric128PackedSingle = "fp_arith_inst_retired_128b_packed_single";
+constexpr char const* kMetric256PackedDouble = "fp_arith_inst_retired_256b_packed_double";
+constexpr char const* kMetric256PackedSingle = "fp_arith_inst_retired_256b_packed_single";
+constexpr char const* kMetric512PackedDouble = "fp_arith_inst_retired_512b_packed_double";
+constexpr char const* kMetric512PackedSingle = "fp_arith_inst_retired_512b_packed_single";
+
+struct PerfKernelBuffers {
+    double* lhs = nullptr;
+    double* rhs = nullptr;
+    double* out = nullptr;
+    float* lhs_f = nullptr;
+    float* rhs_f = nullptr;
+    float* out_f = nullptr;
+    int count = 0;
+};
+
+using PerfKernelFunction = double (*)(PerfKernelBuffers const&);
+
+struct PerfMetricEstimate {
+    std::uint64_t scalar_double = 0;
+    std::uint64_t scalar_single = 0;
+    std::uint64_t packed_128_double = 0;
+    std::uint64_t packed_128_single = 0;
+    std::uint64_t packed_256_double = 0;
+    std::uint64_t packed_256_single = 0;
+    std::uint64_t packed_512_double = 0;
+    std::uint64_t packed_512_single = 0;
+};
+
+struct PerfKernelDescriptor {
+    char const* name = nullptr;
+    PerfKernelFunction function = nullptr;
+    PerfMetricEstimate estimate;
+};
+
+struct PerfKernelInvocation {
+    char const* name = nullptr;
+    PerfKernelFunction function = nullptr;
+};
+
+using PerfGroundTruth = std::map<std::string, std::uint64_t>;
+
+struct PerfSchedule {
+    std::vector<PerfKernelInvocation> kernels;
+    PerfGroundTruth ground_truth_per_iter;
+};
 
 template <typename T>
 inline void doNotOptimize(T const& value) {
@@ -34,8 +93,79 @@ inline void doNotOptimize(T const& value) {
 #endif
 }
 
-inline int perfLoopCount() {
-    return kPerfLoopCount;
+PerfGroundTruth makeEmptyGroundTruth() {
+    return {
+      {kMetricScalarDouble, 0},
+      {kMetricScalarSingle, 0},
+      {kMetric128PackedDouble, 0},
+      {kMetric128PackedSingle, 0},
+      {kMetric256PackedDouble, 0},
+      {kMetric256PackedSingle, 0},
+      {kMetric512PackedDouble, 0},
+      {kMetric512PackedSingle, 0},
+    };
+}
+
+void addEstimate(PerfGroundTruth& ground_truth, PerfMetricEstimate const& estimate) {
+    ground_truth[kMetricScalarDouble] += estimate.scalar_double;
+    ground_truth[kMetricScalarSingle] += estimate.scalar_single;
+    ground_truth[kMetric128PackedDouble] += estimate.packed_128_double;
+    ground_truth[kMetric128PackedSingle] += estimate.packed_128_single;
+    ground_truth[kMetric256PackedDouble] += estimate.packed_256_double;
+    ground_truth[kMetric256PackedSingle] += estimate.packed_256_single;
+    ground_truth[kMetric512PackedDouble] += estimate.packed_512_double;
+    ground_truth[kMetric512PackedSingle] += estimate.packed_512_single;
+}
+
+PerfGroundTruth scaleGroundTruth(PerfGroundTruth const& per_iter, int iters) {
+    PerfGroundTruth scaled = makeEmptyGroundTruth();
+    std::uint64_t const multiplier = static_cast<std::uint64_t>(iters > 0 ? iters : 0);
+    for (auto const& [metric, value] : per_iter) {
+        scaled[metric] = value * multiplier;
+    }
+    return scaled;
+}
+
+std::uint64_t nextShuffleValue(std::uint64_t& state) {
+    state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+    return state;
+}
+
+void deterministicShuffle(std::vector<PerfKernelInvocation>& kernels, std::uint64_t seed) {
+    std::uint64_t state = seed;
+    for (std::size_t i = kernels.size(); i > 1; --i) {
+        std::size_t const j = static_cast<std::size_t>(nextShuffleValue(state) % i);
+        std::swap(kernels[i - 1], kernels[j]);
+    }
+}
+
+std::string sanitizeBenchmarkName(std::string benchmark_name) {
+    if (benchmark_name.empty()) {
+        return "perf";
+    }
+
+    for (char& ch : benchmark_name) {
+        if (!std::isalnum(static_cast<unsigned char>(ch)) && ch != '_' && ch != '-') {
+            ch = '_';
+        }
+    }
+
+    return benchmark_name;
+}
+
+void writePerfGroundTruth(std::string const& benchmark_name, PerfGroundTruth const& ground_truth) {
+    int rank = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    if (rank != 0) {
+        return;
+    }
+
+    std::string const output_name = "perf_ground_truth_" + sanitizeBenchmarkName(benchmark_name) + ".csv";
+    std::ofstream out(output_name, std::ios::out | std::ios::trunc);
+    out << "metric,value\n";
+    for (auto const& [metric, value] : ground_truth) {
+        out << metric << "," << value << "\n";
+    }
 }
 
 #if SLOW_NODE_X86_SIMD && (defined(__GNUC__) || defined(__clang__))
@@ -59,32 +189,33 @@ SimdCapabilities detectSimdCapabilities() {
 }
 
 __attribute__((target("sse2"), noinline))
-double runSseScalarKernel(
-  double* lhs, double* rhs, double* out,
-  float* lhs_f, float* rhs_f, float* out_f,
-  int count, int loops
-) {
+double runSseScalarKernel(PerfKernelBuffers const& buffers) {
     // Primarily drives:
     // - fp_arith_inst_retired_scalar_double
     // - fp_arith_inst_retired_scalar_single
+    double* lhs = buffers.lhs;
+    double* rhs = buffers.rhs;
+    double* out = buffers.out;
+    float* lhs_f = buffers.lhs_f;
+    float* rhs_f = buffers.rhs_f;
+    float* out_f = buffers.out_f;
+    int const count = buffers.count;
     __m128d accum_d = _mm_set_sd(0.25);
     __m128 accum_f = _mm_set_ss(0.5f);
     __m128d damp_d = _mm_set_sd(0.99999988079071044921875);
     __m128 damp_f = _mm_set_ss(0.99999988f);
 
-    for (int loop = 0; loop < loops; ++loop) {
-        for (int i = 0; i < count; ++i) {
-            __m128d lhs_d = _mm_load_sd(lhs + i);
-            __m128d rhs_d = _mm_load_sd(rhs + i);
-            __m128 lhs_s = _mm_load_ss(lhs_f + i);
-            __m128 rhs_s = _mm_load_ss(rhs_f + i);
+    for (int i = 0; i < count; ++i) {
+        __m128d lhs_d = _mm_load_sd(lhs + i);
+        __m128d rhs_d = _mm_load_sd(rhs + i);
+        __m128 lhs_s = _mm_load_ss(lhs_f + i);
+        __m128 rhs_s = _mm_load_ss(rhs_f + i);
 
-            accum_d = _mm_add_sd(_mm_mul_sd(accum_d, damp_d), _mm_mul_sd(lhs_d, rhs_d));
-            accum_f = _mm_add_ss(_mm_mul_ss(accum_f, damp_f), _mm_mul_ss(lhs_s, rhs_s));
+        accum_d = _mm_add_sd(_mm_mul_sd(accum_d, damp_d), _mm_mul_sd(lhs_d, rhs_d));
+        accum_f = _mm_add_ss(_mm_mul_ss(accum_f, damp_f), _mm_mul_ss(lhs_s, rhs_s));
 
-            _mm_store_sd(out + i, accum_d);
-            _mm_store_ss(out_f + i, accum_f);
-        }
+        _mm_store_sd(out + i, accum_d);
+        _mm_store_ss(out_f + i, accum_f);
     }
 
     return _mm_cvtsd_f64(accum_d) + static_cast<double>(_mm_cvtss_f32(accum_f))
@@ -92,14 +223,17 @@ double runSseScalarKernel(
 }
 
 __attribute__((target("sse2"), noinline))
-double runSsePackedKernel(
-  double* lhs, double* rhs, double* out,
-  float* lhs_f, float* rhs_f, float* out_f,
-  int count, int loops
-) {
+double runSsePackedKernel(PerfKernelBuffers const& buffers) {
     // Primarily drives:
     // - fp_arith_inst_retired_128b_packed_double
     // - fp_arith_inst_retired_128b_packed_single
+    double* lhs = buffers.lhs;
+    double* rhs = buffers.rhs;
+    double* out = buffers.out;
+    float* lhs_f = buffers.lhs_f;
+    float* rhs_f = buffers.rhs_f;
+    float* out_f = buffers.out_f;
+    int const count = buffers.count;
     __m128d accum0 = _mm_set1_pd(0.25);
     __m128d accum1 = _mm_set1_pd(0.75);
     __m128 accum_f = _mm_set1_ps(0.5f);
@@ -107,27 +241,25 @@ double runSsePackedKernel(
     __m128d scale_b = _mm_set1_pd(0.9999997615814208984375);
     __m128 scale_f = _mm_set1_ps(1.0000001f);
 
-    for (int loop = 0; loop < loops; ++loop) {
-        for (int i = 0; i < count; i += 4) {
-            __m128d lhs0 = _mm_loadu_pd(lhs + i);
-            __m128d rhs0 = _mm_loadu_pd(rhs + i);
-            __m128d lhs1 = _mm_loadu_pd(lhs + i + 2);
-            __m128d rhs1 = _mm_loadu_pd(rhs + i + 2);
-            __m128 lhs_s = _mm_loadu_ps(lhs_f + i);
-            __m128 rhs_s = _mm_loadu_ps(rhs_f + i);
+    for (int i = 0; i < count; i += 4) {
+        __m128d lhs0 = _mm_loadu_pd(lhs + i);
+        __m128d rhs0 = _mm_loadu_pd(rhs + i);
+        __m128d lhs1 = _mm_loadu_pd(lhs + i + 2);
+        __m128d rhs1 = _mm_loadu_pd(rhs + i + 2);
+        __m128 lhs_s = _mm_loadu_ps(lhs_f + i);
+        __m128 rhs_s = _mm_loadu_ps(rhs_f + i);
 
-            __m128d mix0 = _mm_add_pd(_mm_mul_pd(lhs0, scale_a), rhs0);
-            __m128d mix1 = _mm_sub_pd(_mm_mul_pd(lhs1, scale_b), rhs1);
-            __m128 mix_s = _mm_add_ps(_mm_mul_ps(lhs_s, scale_f), rhs_s);
+        __m128d mix0 = _mm_add_pd(_mm_mul_pd(lhs0, scale_a), rhs0);
+        __m128d mix1 = _mm_sub_pd(_mm_mul_pd(lhs1, scale_b), rhs1);
+        __m128 mix_s = _mm_add_ps(_mm_mul_ps(lhs_s, scale_f), rhs_s);
 
-            accum0 = _mm_add_pd(accum0, _mm_mul_pd(mix0, mix0));
-            accum1 = _mm_add_pd(accum1, _mm_mul_pd(mix1, mix1));
-            accum_f = _mm_add_ps(accum_f, _mm_mul_ps(mix_s, mix_s));
+        accum0 = _mm_add_pd(accum0, _mm_mul_pd(mix0, mix0));
+        accum1 = _mm_add_pd(accum1, _mm_mul_pd(mix1, mix1));
+        accum_f = _mm_add_ps(accum_f, _mm_mul_ps(mix_s, mix_s));
 
-            _mm_storeu_pd(out + i, _mm_add_pd(mix0, accum0));
-            _mm_storeu_pd(out + i + 2, _mm_sub_pd(mix1, accum1));
-            _mm_storeu_ps(out_f + i, _mm_add_ps(mix_s, accum_f));
-        }
+        _mm_storeu_pd(out + i, _mm_add_pd(mix0, accum0));
+        _mm_storeu_pd(out + i + 2, _mm_sub_pd(mix1, accum1));
+        _mm_storeu_ps(out_f + i, _mm_add_ps(mix_s, accum_f));
     }
 
     alignas(16) std::array<double, 2> lane0{};
@@ -142,30 +274,32 @@ double runSsePackedKernel(
 }
 
 __attribute__((target("avx"), noinline))
-double runAvxKernel(double* lhs, double* rhs, double* out, int count, int loops) {
+double runAvxKernel(PerfKernelBuffers const& buffers) {
     // Primarily drives:
     // - fp_arith_inst_retired_256b_packed_double
+    double* lhs = buffers.lhs;
+    double* rhs = buffers.rhs;
+    double* out = buffers.out;
+    int const count = buffers.count;
     __m256d accum0 = _mm256_set1_pd(0.5);
     __m256d accum1 = _mm256_set1_pd(1.5);
     __m256d bias = _mm256_setr_pd(1.0, -1.0, 0.5, -0.5);
     __m256d scale = _mm256_set1_pd(1.0000002384185791015625);
 
-    for (int loop = 0; loop < loops; ++loop) {
-        for (int i = 0; i < count; i += 8) {
-            __m256d lhs0 = _mm256_loadu_pd(lhs + i);
-            __m256d rhs0 = _mm256_loadu_pd(rhs + i);
-            __m256d lhs1 = _mm256_loadu_pd(lhs + i + 4);
-            __m256d rhs1 = _mm256_loadu_pd(rhs + i + 4);
+    for (int i = 0; i < count; i += 8) {
+        __m256d lhs0 = _mm256_loadu_pd(lhs + i);
+        __m256d rhs0 = _mm256_loadu_pd(rhs + i);
+        __m256d lhs1 = _mm256_loadu_pd(lhs + i + 4);
+        __m256d rhs1 = _mm256_loadu_pd(rhs + i + 4);
 
-            __m256d mix0 = _mm256_add_pd(_mm256_mul_pd(lhs0, scale), _mm256_add_pd(rhs0, bias));
-            __m256d mix1 = _mm256_sub_pd(_mm256_mul_pd(rhs1, scale), _mm256_sub_pd(lhs1, bias));
+        __m256d mix0 = _mm256_add_pd(_mm256_mul_pd(lhs0, scale), _mm256_add_pd(rhs0, bias));
+        __m256d mix1 = _mm256_sub_pd(_mm256_mul_pd(rhs1, scale), _mm256_sub_pd(lhs1, bias));
 
-            accum0 = _mm256_add_pd(accum0, _mm256_mul_pd(mix0, mix0));
-            accum1 = _mm256_add_pd(accum1, _mm256_mul_pd(mix1, mix1));
+        accum0 = _mm256_add_pd(accum0, _mm256_mul_pd(mix0, mix0));
+        accum1 = _mm256_add_pd(accum1, _mm256_mul_pd(mix1, mix1));
 
-            _mm256_storeu_pd(out + i, _mm256_add_pd(mix0, accum0));
-            _mm256_storeu_pd(out + i + 4, _mm256_sub_pd(mix1, accum1));
-        }
+        _mm256_storeu_pd(out + i, _mm256_add_pd(mix0, accum0));
+        _mm256_storeu_pd(out + i + 4, _mm256_sub_pd(mix1, accum1));
     }
 
     alignas(32) std::array<double, 4> lanes0{};
@@ -177,30 +311,32 @@ double runAvxKernel(double* lhs, double* rhs, double* out, int count, int loops)
 }
 
 __attribute__((target("avx"), noinline))
-double runAvxSingleKernel(float* lhs, float* rhs, float* out, int count, int loops) {
+double runAvxSingleKernel(PerfKernelBuffers const& buffers) {
     // Primarily drives:
     // - fp_arith_inst_retired_256b_packed_single
+    float* lhs = buffers.lhs_f;
+    float* rhs = buffers.rhs_f;
+    float* out = buffers.out_f;
+    int const count = buffers.count;
     __m256 accum0 = _mm256_set1_ps(0.5f);
     __m256 accum1 = _mm256_set1_ps(1.5f);
     __m256 bias = _mm256_setr_ps(1.0f, -1.0f, 0.5f, -0.5f, 2.0f, -2.0f, 3.0f, -3.0f);
     __m256 scale = _mm256_set1_ps(1.0000002f);
 
-    for (int loop = 0; loop < loops; ++loop) {
-        for (int i = 0; i < count; i += 16) {
-            __m256 lhs0 = _mm256_loadu_ps(lhs + i);
-            __m256 rhs0 = _mm256_loadu_ps(rhs + i);
-            __m256 lhs1 = _mm256_loadu_ps(lhs + i + 8);
-            __m256 rhs1 = _mm256_loadu_ps(rhs + i + 8);
+    for (int i = 0; i < count; i += 16) {
+        __m256 lhs0 = _mm256_loadu_ps(lhs + i);
+        __m256 rhs0 = _mm256_loadu_ps(rhs + i);
+        __m256 lhs1 = _mm256_loadu_ps(lhs + i + 8);
+        __m256 rhs1 = _mm256_loadu_ps(rhs + i + 8);
 
-            __m256 mix0 = _mm256_add_ps(_mm256_mul_ps(lhs0, scale), _mm256_add_ps(rhs0, bias));
-            __m256 mix1 = _mm256_sub_ps(_mm256_mul_ps(rhs1, scale), _mm256_sub_ps(lhs1, bias));
+        __m256 mix0 = _mm256_add_ps(_mm256_mul_ps(lhs0, scale), _mm256_add_ps(rhs0, bias));
+        __m256 mix1 = _mm256_sub_ps(_mm256_mul_ps(rhs1, scale), _mm256_sub_ps(lhs1, bias));
 
-            accum0 = _mm256_add_ps(accum0, _mm256_mul_ps(mix0, mix0));
-            accum1 = _mm256_add_ps(accum1, _mm256_mul_ps(mix1, mix1));
+        accum0 = _mm256_add_ps(accum0, _mm256_mul_ps(mix0, mix0));
+        accum1 = _mm256_add_ps(accum1, _mm256_mul_ps(mix1, mix1));
 
-            _mm256_storeu_ps(out + i, _mm256_add_ps(mix0, accum0));
-            _mm256_storeu_ps(out + i + 8, _mm256_sub_ps(mix1, accum1));
-        }
+        _mm256_storeu_ps(out + i, _mm256_add_ps(mix0, accum0));
+        _mm256_storeu_ps(out + i + 8, _mm256_sub_ps(mix1, accum1));
     }
 
     alignas(32) std::array<float, 8> lanes0{};
@@ -218,27 +354,29 @@ double runAvxSingleKernel(float* lhs, float* rhs, float* out, int count, int loo
 }
 
 __attribute__((target("avx"), noinline))
-double runAvxComplexKernel(double* lhs, double* rhs, double* out, int count, int loops) {
+double runAvxComplexKernel(PerfKernelBuffers const& buffers) {
     // Primarily drives:
     // - fp_arith_inst_retired_256b_packed_double
     // This path is only used for complex<double> runs.
+    double* lhs = buffers.lhs;
+    double* rhs = buffers.rhs;
+    double* out = buffers.out;
+    int const count = buffers.count;
     __m256d accum = _mm256_setr_pd(0.125, -0.125, 0.25, -0.25);
 
-    for (int loop = 0; loop < loops; ++loop) {
-        for (int i = 0; i < count; i += 4) {
-            __m256d lhs_vec = _mm256_loadu_pd(lhs + i);
-            __m256d rhs_vec = _mm256_loadu_pd(rhs + i);
-            __m256d lhs_real = _mm256_movedup_pd(lhs_vec);
-            __m256d lhs_imag = _mm256_permute_pd(lhs_vec, 0xF);
-            __m256d rhs_swapped = _mm256_permute_pd(rhs_vec, 0x5);
+    for (int i = 0; i < count; i += 4) {
+        __m256d lhs_vec = _mm256_loadu_pd(lhs + i);
+        __m256d rhs_vec = _mm256_loadu_pd(rhs + i);
+        __m256d lhs_real = _mm256_movedup_pd(lhs_vec);
+        __m256d lhs_imag = _mm256_permute_pd(lhs_vec, 0xF);
+        __m256d rhs_swapped = _mm256_permute_pd(rhs_vec, 0x5);
 
-            __m256d prod0 = _mm256_mul_pd(lhs_real, rhs_vec);
-            __m256d prod1 = _mm256_mul_pd(lhs_imag, rhs_swapped);
-            __m256d complex_value = _mm256_addsub_pd(prod0, prod1);
+        __m256d prod0 = _mm256_mul_pd(lhs_real, rhs_vec);
+        __m256d prod1 = _mm256_mul_pd(lhs_imag, rhs_swapped);
+        __m256d complex_value = _mm256_addsub_pd(prod0, prod1);
 
-            accum = _mm256_add_pd(accum, complex_value);
-            _mm256_storeu_pd(out + i, _mm256_add_pd(complex_value, accum));
-        }
+        accum = _mm256_add_pd(accum, complex_value);
+        _mm256_storeu_pd(out + i, _mm256_add_pd(complex_value, accum));
     }
 
     alignas(32) std::array<double, 4> lanes{};
@@ -247,28 +385,30 @@ double runAvxComplexKernel(double* lhs, double* rhs, double* out, int count, int
 }
 
 __attribute__((target("avx2,fma"), noinline))
-double runAvx2FmaKernel(double* lhs, double* rhs, double* out, int count, int loops) {
+double runAvx2FmaKernel(PerfKernelBuffers const& buffers) {
     // Primarily drives:
     // - fp_arith_inst_retired_256b_packed_double
     // Uses FMA instructions; counts are still reflected in retired FP arithmetic events.
+    double* lhs = buffers.lhs;
+    double* rhs = buffers.rhs;
+    double* out = buffers.out;
+    int const count = buffers.count;
     __m256d accum = _mm256_set1_pd(0.125);
     __m256d shift = _mm256_setr_pd(0.25, 0.5, 0.75, 1.0);
 
-    for (int loop = 0; loop < loops; ++loop) {
-        for (int i = 0; i < count; i += 8) {
-            __m256d lhs0 = _mm256_loadu_pd(lhs + i);
-            __m256d rhs0 = _mm256_loadu_pd(rhs + i);
-            __m256d lhs1 = _mm256_loadu_pd(lhs + i + 4);
-            __m256d rhs1 = _mm256_loadu_pd(rhs + i + 4);
+    for (int i = 0; i < count; i += 8) {
+        __m256d lhs0 = _mm256_loadu_pd(lhs + i);
+        __m256d rhs0 = _mm256_loadu_pd(rhs + i);
+        __m256d lhs1 = _mm256_loadu_pd(lhs + i + 4);
+        __m256d rhs1 = _mm256_loadu_pd(rhs + i + 4);
 
-            __m256d fused0 = _mm256_fmadd_pd(lhs0, rhs0, shift);
-            __m256d fused1 = _mm256_fnmadd_pd(lhs1, rhs1, shift);
+        __m256d fused0 = _mm256_fmadd_pd(lhs0, rhs0, shift);
+        __m256d fused1 = _mm256_fnmadd_pd(lhs1, rhs1, shift);
 
-            accum = _mm256_add_pd(accum, _mm256_add_pd(fused0, fused1));
+        accum = _mm256_add_pd(accum, _mm256_add_pd(fused0, fused1));
 
-            _mm256_storeu_pd(out + i, _mm256_add_pd(fused0, accum));
-            _mm256_storeu_pd(out + i + 4, _mm256_sub_pd(fused1, accum));
-        }
+        _mm256_storeu_pd(out + i, _mm256_add_pd(fused0, accum));
+        _mm256_storeu_pd(out + i + 4, _mm256_sub_pd(fused1, accum));
     }
 
     alignas(32) std::array<double, 4> lanes{};
@@ -277,28 +417,30 @@ double runAvx2FmaKernel(double* lhs, double* rhs, double* out, int count, int lo
 }
 
 __attribute__((target("avx2,fma"), noinline))
-double runAvx2FmaSingleKernel(float* lhs, float* rhs, float* out, int count, int loops) {
+double runAvx2FmaSingleKernel(PerfKernelBuffers const& buffers) {
     // Primarily drives:
     // - fp_arith_inst_retired_256b_packed_single
     // Uses FMA instructions; counts are still reflected in retired FP arithmetic events.
+    float* lhs = buffers.lhs_f;
+    float* rhs = buffers.rhs_f;
+    float* out = buffers.out_f;
+    int const count = buffers.count;
     __m256 accum = _mm256_set1_ps(0.125f);
     __m256 shift = _mm256_setr_ps(0.25f, 0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f);
 
-    for (int loop = 0; loop < loops; ++loop) {
-        for (int i = 0; i < count; i += 16) {
-            __m256 lhs0 = _mm256_loadu_ps(lhs + i);
-            __m256 rhs0 = _mm256_loadu_ps(rhs + i);
-            __m256 lhs1 = _mm256_loadu_ps(lhs + i + 8);
-            __m256 rhs1 = _mm256_loadu_ps(rhs + i + 8);
+    for (int i = 0; i < count; i += 16) {
+        __m256 lhs0 = _mm256_loadu_ps(lhs + i);
+        __m256 rhs0 = _mm256_loadu_ps(rhs + i);
+        __m256 lhs1 = _mm256_loadu_ps(lhs + i + 8);
+        __m256 rhs1 = _mm256_loadu_ps(rhs + i + 8);
 
-            __m256 fused0 = _mm256_fmadd_ps(lhs0, rhs0, shift);
-            __m256 fused1 = _mm256_fnmadd_ps(lhs1, rhs1, shift);
+        __m256 fused0 = _mm256_fmadd_ps(lhs0, rhs0, shift);
+        __m256 fused1 = _mm256_fnmadd_ps(lhs1, rhs1, shift);
 
-            accum = _mm256_add_ps(accum, _mm256_add_ps(fused0, fused1));
+        accum = _mm256_add_ps(accum, _mm256_add_ps(fused0, fused1));
 
-            _mm256_storeu_ps(out + i, _mm256_add_ps(fused0, accum));
-            _mm256_storeu_ps(out + i + 8, _mm256_sub_ps(fused1, accum));
-        }
+        _mm256_storeu_ps(out + i, _mm256_add_ps(fused0, accum));
+        _mm256_storeu_ps(out + i + 8, _mm256_sub_ps(fused1, accum));
     }
 
     alignas(32) std::array<float, 8> lanes{};
@@ -311,27 +453,29 @@ double runAvx2FmaSingleKernel(float* lhs, float* rhs, float* out, int count, int
 }
 
 __attribute__((target("avx512f"), noinline))
-double runAvx512Kernel(double* lhs, double* rhs, double* out, int count, int loops) {
+double runAvx512Kernel(PerfKernelBuffers const& buffers) {
     // Primarily drives:
     // - fp_arith_inst_retired_512b_packed_double
+    double* lhs = buffers.lhs;
+    double* rhs = buffers.rhs;
+    double* out = buffers.out;
+    int const count = buffers.count;
     __m512d accum = _mm512_set1_pd(0.0625);
     __m512d blend = _mm512_setr_pd(1.0, -1.0, 2.0, -2.0, 3.0, -3.0, 4.0, -4.0);
 
-    for (int loop = 0; loop < loops; ++loop) {
-        for (int i = 0; i < count; i += 16) {
-            __m512d lhs0 = _mm512_loadu_pd(lhs + i);
-            __m512d rhs0 = _mm512_loadu_pd(rhs + i);
-            __m512d lhs1 = _mm512_loadu_pd(lhs + i + 8);
-            __m512d rhs1 = _mm512_loadu_pd(rhs + i + 8);
+    for (int i = 0; i < count; i += 16) {
+        __m512d lhs0 = _mm512_loadu_pd(lhs + i);
+        __m512d rhs0 = _mm512_loadu_pd(rhs + i);
+        __m512d lhs1 = _mm512_loadu_pd(lhs + i + 8);
+        __m512d rhs1 = _mm512_loadu_pd(rhs + i + 8);
 
-            __m512d mix0 = _mm512_add_pd(_mm512_mul_pd(lhs0, rhs0), blend);
-            __m512d mix1 = _mm512_sub_pd(_mm512_mul_pd(lhs1, rhs1), blend);
+        __m512d mix0 = _mm512_add_pd(_mm512_mul_pd(lhs0, rhs0), blend);
+        __m512d mix1 = _mm512_sub_pd(_mm512_mul_pd(lhs1, rhs1), blend);
 
-            accum = _mm512_add_pd(accum, _mm512_add_pd(mix0, mix1));
+        accum = _mm512_add_pd(accum, _mm512_add_pd(mix0, mix1));
 
-            _mm512_storeu_pd(out + i, _mm512_add_pd(mix0, accum));
-            _mm512_storeu_pd(out + i + 8, _mm512_sub_pd(mix1, accum));
-        }
+        _mm512_storeu_pd(out + i, _mm512_add_pd(mix0, accum));
+        _mm512_storeu_pd(out + i + 8, _mm512_sub_pd(mix1, accum));
     }
 
     alignas(64) std::array<double, 8> lanes{};
@@ -341,30 +485,32 @@ double runAvx512Kernel(double* lhs, double* rhs, double* out, int count, int loo
 }
 
 __attribute__((target("avx512f"), noinline))
-double runAvx512SingleKernel(float* lhs, float* rhs, float* out, int count, int loops) {
+double runAvx512SingleKernel(PerfKernelBuffers const& buffers) {
     // Primarily drives:
     // - fp_arith_inst_retired_512b_packed_single
+    float* lhs = buffers.lhs_f;
+    float* rhs = buffers.rhs_f;
+    float* out = buffers.out_f;
+    int const count = buffers.count;
     __m512 accum = _mm512_set1_ps(0.0625f);
     __m512 blend = _mm512_setr_ps(
       1.0f, -1.0f, 2.0f, -2.0f, 3.0f, -3.0f, 4.0f, -4.0f,
       5.0f, -5.0f, 6.0f, -6.0f, 7.0f, -7.0f, 8.0f, -8.0f
     );
 
-    for (int loop = 0; loop < loops; ++loop) {
-        for (int i = 0; i < count; i += 32) {
-            __m512 lhs0 = _mm512_loadu_ps(lhs + i);
-            __m512 rhs0 = _mm512_loadu_ps(rhs + i);
-            __m512 lhs1 = _mm512_loadu_ps(lhs + i + 16);
-            __m512 rhs1 = _mm512_loadu_ps(rhs + i + 16);
+    for (int i = 0; i < count; i += 32) {
+        __m512 lhs0 = _mm512_loadu_ps(lhs + i);
+        __m512 rhs0 = _mm512_loadu_ps(rhs + i);
+        __m512 lhs1 = _mm512_loadu_ps(lhs + i + 16);
+        __m512 rhs1 = _mm512_loadu_ps(rhs + i + 16);
 
-            __m512 mix0 = _mm512_add_ps(_mm512_mul_ps(lhs0, rhs0), blend);
-            __m512 mix1 = _mm512_sub_ps(_mm512_mul_ps(lhs1, rhs1), blend);
+        __m512 mix0 = _mm512_add_ps(_mm512_mul_ps(lhs0, rhs0), blend);
+        __m512 mix1 = _mm512_sub_ps(_mm512_mul_ps(lhs1, rhs1), blend);
 
-            accum = _mm512_add_ps(accum, _mm512_add_ps(mix0, mix1));
+        accum = _mm512_add_ps(accum, _mm512_add_ps(mix0, mix1));
 
-            _mm512_storeu_ps(out + i, _mm512_add_ps(mix0, accum));
-            _mm512_storeu_ps(out + i + 16, _mm512_sub_ps(mix1, accum));
-        }
+        _mm512_storeu_ps(out + i, _mm512_add_ps(mix0, accum));
+        _mm512_storeu_ps(out + i + 16, _mm512_sub_ps(mix1, accum));
     }
 
     alignas(64) std::array<float, 16> lanes{};
@@ -378,68 +524,173 @@ double runAvx512SingleKernel(float* lhs, float* rhs, float* out, int count, int 
 
 #endif
 
-double runScalarPerfKernel(double* lhs, double* rhs, double* out, int count, int loops) {
+double runScalarPerfKernel(PerfKernelBuffers const& buffers) {
     // Primarily drives:
     // - fp_arith_inst_retired_scalar_double
     // Also contributes to generic events such as instructions/cycles.
+    double* lhs = buffers.lhs;
+    double* rhs = buffers.rhs;
+    double* out = buffers.out;
+    int const count = buffers.count;
     double accum0 = 0.25;
     double accum1 = 0.75;
     double accum2 = -0.5;
 
-    for (int loop = 0; loop < loops; ++loop) {
-        for (int i = 0; i < count; ++i) {
-            double value0 = lhs[i] * rhs[i] + accum0;
-            double value1 = lhs[i] - rhs[i] * accum1;
-            accum2 += (value0 * value0) - (value1 * value1);
-            out[i] = value0 + value1 + accum2;
-            accum0 += value0 * 1.0e-8;
-            accum1 += value1 * 1.0e-8;
-        }
+    for (int i = 0; i < count; ++i) {
+        double value0 = lhs[i] * rhs[i] + accum0;
+        double value1 = lhs[i] - rhs[i] * accum1;
+        accum2 += (value0 * value0) - (value1 * value1);
+        out[i] = value0 + value1 + accum2;
+        accum0 += value0 * 1.0e-8;
+        accum1 += value1 * 1.0e-8;
     }
 
     return accum0 + accum1 + accum2 + out[count - 1];
 }
 
-template <typename T>
-double runPerfInstructionMix(
-    double* lhs, double* rhs, double* out,
-    float* lhs_f, float* rhs_f, float* out_f
-) {
-    // This intentionally mixes scalar/SSE/AVX/AVX2/FMA/AVX-512 kernels so that
-    // a wide VT_EVENTS list can be exercised in one short benchmark window.
-    // ISA-specific counters remain near zero when that ISA is unavailable.
-    double checksum = 0.0;
-    int const count = kPerfVectorLength;
-    int const loops = perfLoopCount();
+PerfMetricEstimate estimateScalarKernel(int count) {
+    PerfMetricEstimate estimate;
+    // Heuristic scalar loop: 7 muls + 7 adds/subs per element.
+    estimate.scalar_double = 14ULL * static_cast<std::uint64_t>(count);
+    return estimate;
+}
 
-    checksum += runScalarPerfKernel(lhs, rhs, out, count, loops / 8);
+PerfMetricEstimate estimateSseScalarKernel(int count) {
+    PerfMetricEstimate estimate;
+    // 2 muls + 1 add for each scalar double and scalar single lane.
+    estimate.scalar_double = 3ULL * static_cast<std::uint64_t>(count);
+    estimate.scalar_single = 3ULL * static_cast<std::uint64_t>(count);
+    return estimate;
+}
+
+PerfMetricEstimate estimateSsePackedKernel(int count) {
+    PerfMetricEstimate estimate;
+    std::uint64_t const groups = static_cast<std::uint64_t>(count / 4);
+    estimate.packed_128_double = 10ULL * groups;
+    estimate.packed_128_single = 5ULL * groups;
+    return estimate;
+}
+
+PerfMetricEstimate estimateAvxKernel(int count) {
+    PerfMetricEstimate estimate;
+    std::uint64_t const groups = static_cast<std::uint64_t>(count / 8);
+    estimate.packed_256_double = 12ULL * groups;
+    return estimate;
+}
+
+PerfMetricEstimate estimateAvxSingleKernel(int count) {
+    PerfMetricEstimate estimate;
+    std::uint64_t const groups = static_cast<std::uint64_t>(count / 16);
+    estimate.packed_256_single = 12ULL * groups;
+    return estimate;
+}
+
+PerfMetricEstimate estimateAvxComplexKernel(int count) {
+    PerfMetricEstimate estimate;
+    std::uint64_t const groups = static_cast<std::uint64_t>(count / 4);
+    estimate.packed_256_double = 5ULL * groups;
+    return estimate;
+}
+
+PerfMetricEstimate estimateAvx2FmaKernel(int count) {
+    PerfMetricEstimate estimate;
+    std::uint64_t const groups = static_cast<std::uint64_t>(count / 8);
+    estimate.packed_256_double = 6ULL * groups;
+    return estimate;
+}
+
+PerfMetricEstimate estimateAvx2FmaSingleKernel(int count) {
+    PerfMetricEstimate estimate;
+    std::uint64_t const groups = static_cast<std::uint64_t>(count / 16);
+    estimate.packed_256_single = 6ULL * groups;
+    return estimate;
+}
+
+PerfMetricEstimate estimateAvx512Kernel(int count) {
+    PerfMetricEstimate estimate;
+    std::uint64_t const groups = static_cast<std::uint64_t>(count / 16);
+    estimate.packed_512_double = 8ULL * groups;
+    return estimate;
+}
+
+PerfMetricEstimate estimateAvx512SingleKernel(int count) {
+    PerfMetricEstimate estimate;
+    std::uint64_t const groups = static_cast<std::uint64_t>(count / 32);
+    estimate.packed_512_single = 8ULL * groups;
+    return estimate;
+}
+
+template <typename T>
+std::vector<PerfKernelDescriptor> buildPerfKernelDescriptors(int count) {
+    std::vector<PerfKernelDescriptor> descriptors;
+    descriptors.push_back({"scalar", runScalarPerfKernel, estimateScalarKernel(count)});
 
 #if SLOW_NODE_X86_SIMD && (defined(__GNUC__) || defined(__clang__))
     SimdCapabilities const capabilities = detectSimdCapabilities();
 
     if (capabilities.sse2) {
-        checksum += runSseScalarKernel(lhs, rhs, out, lhs_f, rhs_f, out_f, count, loops / 8);
-        checksum += runSsePackedKernel(lhs, rhs, out, lhs_f, rhs_f, out_f, count, loops / 8);
+        descriptors.push_back({"sse_scalar", runSseScalarKernel, estimateSseScalarKernel(count)});
+        descriptors.push_back({"sse_packed", runSsePackedKernel, estimateSsePackedKernel(count)});
     }
 
     if (capabilities.avx) {
-        checksum += runAvxKernel(lhs, rhs, out, count, loops / 8);
-        checksum += runAvxSingleKernel(lhs_f, rhs_f, out_f, count, loops / 8);
+        descriptors.push_back({"avx_double", runAvxKernel, estimateAvxKernel(count)});
+        descriptors.push_back({"avx_single", runAvxSingleKernel, estimateAvxSingleKernel(count)});
         if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
-            checksum += runAvxComplexKernel(lhs, rhs, out, count, loops / 8);
+            descriptors.push_back({"avx_complex", runAvxComplexKernel, estimateAvxComplexKernel(count)});
         }
     }
 
     if (capabilities.avx2_fma) {
-        checksum += runAvx2FmaKernel(lhs, rhs, out, count, loops / 8);
-        checksum += runAvx2FmaSingleKernel(lhs_f, rhs_f, out_f, count, loops / 8);
+        descriptors.push_back({"avx2_fma_double", runAvx2FmaKernel, estimateAvx2FmaKernel(count)});
+        descriptors.push_back({"avx2_fma_single", runAvx2FmaSingleKernel, estimateAvx2FmaSingleKernel(count)});
     }
 
     if (capabilities.avx512f) {
-        checksum += runAvx512Kernel(lhs, rhs, out, count, loops / 8);
-        checksum += runAvx512SingleKernel(lhs_f, rhs_f, out_f, count, loops / 8);
+        descriptors.push_back({"avx512_double", runAvx512Kernel, estimateAvx512Kernel(count)});
+        descriptors.push_back({"avx512_single", runAvx512SingleKernel, estimateAvx512SingleKernel(count)});
     }
 #endif
+
+    return descriptors;
+}
+
+template <typename T>
+std::uint64_t shuffleSeedForBenchmark() {
+    if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
+        return kPerfShuffleSeed ^ 0x9e3779b97f4a7c15ULL;
+    }
+
+    return kPerfShuffleSeed;
+}
+
+template <typename T>
+PerfSchedule buildPerfSchedule(int count) {
+    PerfSchedule schedule;
+    schedule.ground_truth_per_iter = makeEmptyGroundTruth();
+
+    std::vector<PerfKernelDescriptor> const descriptors = buildPerfKernelDescriptors<T>(count);
+    schedule.kernels.reserve(descriptors.size() * static_cast<std::size_t>(kPerfKernelRepeatCount));
+
+    for (PerfKernelDescriptor const& descriptor : descriptors) {
+        for (int repeat = 0; repeat < kPerfKernelRepeatCount; ++repeat) {
+            schedule.kernels.push_back({descriptor.name, descriptor.function});
+            addEstimate(schedule.ground_truth_per_iter, descriptor.estimate);
+        }
+    }
+
+    deterministicShuffle(schedule.kernels, shuffleSeedForBenchmark<T>());
+    return schedule;
+}
+
+double runPerfInstructionMix(PerfKernelBuffers const& buffers, PerfSchedule const& schedule) {
+    // This intentionally mixes scalar/SSE/AVX/AVX2/FMA/AVX-512 kernels so that
+    // a wide VT_EVENTS list can be exercised in one short benchmark window.
+    // ISA-specific counters remain near zero when that ISA is unavailable.
+    double checksum = 0.0;
+    for (PerfKernelInvocation const& kernel : schedule.kernels) {
+        checksum += kernel.function(buffers);
+    }
 
     return checksum;
 }
@@ -472,15 +723,18 @@ benchmark_results_t runTimedPerfBenchmark(char const* benchmark_name, int iters)
     iter_timings.reserve(iters > kPerfWarmupIters ? iters - kPerfWarmupIters : 0);
     double total_time = 0.0;
     double checksum = 0.0;
+    PerfKernelBuffers buffers{
+      lhs.data(), rhs.data(), out.data(), lhs_f.data(), rhs_f.data(), out_f.data(), kPerfVectorLength
+    };
+    PerfSchedule const schedule = buildPerfSchedule<T>(kPerfVectorLength);
+    PerfGroundTruth const ground_truth = scaleGroundTruth(schedule.ground_truth_per_iter, iters);
 
     MPI_Barrier(MPI_COMM_WORLD);
     perf::startMeasurements();
 
     for (int i = 0; i < iters; ++i) {
         Kokkos::Timer timer;
-        checksum += runPerfInstructionMix<T>(
-          lhs.data(), rhs.data(), out.data(), lhs_f.data(), rhs_f.data(), out_f.data()
-        );
+        checksum += runPerfInstructionMix(buffers, schedule);
 
         if (i >= kPerfWarmupIters) {
             double const elapsed = timer.seconds();
@@ -490,6 +744,7 @@ benchmark_results_t runTimedPerfBenchmark(char const* benchmark_name, int iters)
     }
 
     perf::stopMeasurements(benchmark_name);
+    writePerfGroundTruth(benchmark_name, ground_truth);
     doNotOptimize(checksum);
 
     int rank = -1;

--- a/src/perf_benchmark.cc
+++ b/src/perf_benchmark.cc
@@ -25,7 +25,6 @@
 #endif
 
 namespace benchmarks {
-
 namespace {
 
 constexpr int kPerfWarmupIters = 1;
@@ -73,7 +72,6 @@ struct PerfKernelDescriptor {
 };
 
 struct PerfKernelInvocation {
-    char const* name = nullptr;
     PerfKernelFunction function = nullptr;
 };
 
@@ -173,7 +171,6 @@ void writePerfGroundTruth(std::string const& benchmark_name, PerfGroundTruth con
 struct SimdCapabilities {
     bool sse2 = false;
     bool avx = false;
-    bool avx2_fma = false;
     bool avx512f = false;
 };
 
@@ -183,16 +180,12 @@ SimdCapabilities detectSimdCapabilities() {
     SimdCapabilities capabilities;
     capabilities.sse2 = __builtin_cpu_supports("sse2");
     capabilities.avx = __builtin_cpu_supports("avx");
-    capabilities.avx2_fma = __builtin_cpu_supports("avx2") && __builtin_cpu_supports("fma");
     capabilities.avx512f = __builtin_cpu_supports("avx512f");
     return capabilities;
 }
 
 __attribute__((target("sse2"), noinline))
 double runSseScalarKernel(PerfKernelBuffers const& buffers) {
-    // Primarily drives:
-    // - fp_arith_inst_retired_scalar_double
-    // - fp_arith_inst_retired_scalar_single
     double* lhs = buffers.lhs;
     double* rhs = buffers.rhs;
     double* out = buffers.out;
@@ -200,6 +193,7 @@ double runSseScalarKernel(PerfKernelBuffers const& buffers) {
     float* rhs_f = buffers.rhs_f;
     float* out_f = buffers.out_f;
     int const count = buffers.count;
+
     __m128d accum_d = _mm_set_sd(0.25);
     __m128 accum_f = _mm_set_ss(0.5f);
     __m128d damp_d = _mm_set_sd(0.99999988079071044921875);
@@ -224,9 +218,6 @@ double runSseScalarKernel(PerfKernelBuffers const& buffers) {
 
 __attribute__((target("sse2"), noinline))
 double runSsePackedKernel(PerfKernelBuffers const& buffers) {
-    // Primarily drives:
-    // - fp_arith_inst_retired_128b_packed_double
-    // - fp_arith_inst_retired_128b_packed_single
     double* lhs = buffers.lhs;
     double* rhs = buffers.rhs;
     double* out = buffers.out;
@@ -234,6 +225,7 @@ double runSsePackedKernel(PerfKernelBuffers const& buffers) {
     float* rhs_f = buffers.rhs_f;
     float* out_f = buffers.out_f;
     int const count = buffers.count;
+
     __m128d accum0 = _mm_set1_pd(0.25);
     __m128d accum1 = _mm_set1_pd(0.75);
     __m128 accum_f = _mm_set1_ps(0.5f);
@@ -268,19 +260,19 @@ double runSsePackedKernel(PerfKernelBuffers const& buffers) {
     _mm_store_pd(lane0.data(), accum0);
     _mm_store_pd(lane1.data(), accum1);
     _mm_store_ps(lanes_f.data(), accum_f);
+
     return lane0[0] + lane0[1] + lane1[0] + lane1[1]
       + lanes_f[0] + lanes_f[1] + lanes_f[2] + lanes_f[3]
       + out[count - 1] + static_cast<double>(out_f[count - 1]);
 }
 
 __attribute__((target("avx"), noinline))
-double runAvxKernel(PerfKernelBuffers const& buffers) {
-    // Primarily drives:
-    // - fp_arith_inst_retired_256b_packed_double
+double runAvxDoubleKernel(PerfKernelBuffers const& buffers) {
     double* lhs = buffers.lhs;
     double* rhs = buffers.rhs;
     double* out = buffers.out;
     int const count = buffers.count;
+
     __m256d accum0 = _mm256_set1_pd(0.5);
     __m256d accum1 = _mm256_set1_pd(1.5);
     __m256d bias = _mm256_setr_pd(1.0, -1.0, 0.5, -0.5);
@@ -306,18 +298,18 @@ double runAvxKernel(PerfKernelBuffers const& buffers) {
     alignas(32) std::array<double, 4> lanes1{};
     _mm256_store_pd(lanes0.data(), accum0);
     _mm256_store_pd(lanes1.data(), accum1);
+
     return lanes0[0] + lanes0[1] + lanes0[2] + lanes0[3]
       + lanes1[0] + lanes1[1] + lanes1[2] + lanes1[3] + out[count - 2];
 }
 
 __attribute__((target("avx"), noinline))
 double runAvxSingleKernel(PerfKernelBuffers const& buffers) {
-    // Primarily drives:
-    // - fp_arith_inst_retired_256b_packed_single
     float* lhs = buffers.lhs_f;
     float* rhs = buffers.rhs_f;
     float* out = buffers.out_f;
     int const count = buffers.count;
+
     __m256 accum0 = _mm256_set1_ps(0.5f);
     __m256 accum1 = _mm256_set1_ps(1.5f);
     __m256 bias = _mm256_setr_ps(1.0f, -1.0f, 0.5f, -0.5f, 2.0f, -2.0f, 3.0f, -3.0f);
@@ -343,6 +335,7 @@ double runAvxSingleKernel(PerfKernelBuffers const& buffers) {
     alignas(32) std::array<float, 8> lanes1{};
     _mm256_store_ps(lanes0.data(), accum0);
     _mm256_store_ps(lanes1.data(), accum1);
+
     double sum = static_cast<double>(out[count - 2]);
     for (float value : lanes0) {
         sum += value;
@@ -353,115 +346,15 @@ double runAvxSingleKernel(PerfKernelBuffers const& buffers) {
     return sum;
 }
 
-__attribute__((target("avx"), noinline))
-double runAvxComplexKernel(PerfKernelBuffers const& buffers) {
-    // Primarily drives:
-    // - fp_arith_inst_retired_256b_packed_double
-    // This path is only used for complex<double> runs.
-    double* lhs = buffers.lhs;
-    double* rhs = buffers.rhs;
-    double* out = buffers.out;
-    int const count = buffers.count;
-    __m256d accum = _mm256_setr_pd(0.125, -0.125, 0.25, -0.25);
-
-    for (int i = 0; i < count; i += 4) {
-        __m256d lhs_vec = _mm256_loadu_pd(lhs + i);
-        __m256d rhs_vec = _mm256_loadu_pd(rhs + i);
-        __m256d lhs_real = _mm256_movedup_pd(lhs_vec);
-        __m256d lhs_imag = _mm256_permute_pd(lhs_vec, 0xF);
-        __m256d rhs_swapped = _mm256_permute_pd(rhs_vec, 0x5);
-
-        __m256d prod0 = _mm256_mul_pd(lhs_real, rhs_vec);
-        __m256d prod1 = _mm256_mul_pd(lhs_imag, rhs_swapped);
-        __m256d complex_value = _mm256_addsub_pd(prod0, prod1);
-
-        accum = _mm256_add_pd(accum, complex_value);
-        _mm256_storeu_pd(out + i, _mm256_add_pd(complex_value, accum));
-    }
-
-    alignas(32) std::array<double, 4> lanes{};
-    _mm256_store_pd(lanes.data(), accum);
-    return lanes[0] + lanes[1] + lanes[2] + lanes[3] + out[count - 1];
-}
-
-__attribute__((target("avx2,fma"), noinline))
-double runAvx2FmaKernel(PerfKernelBuffers const& buffers) {
-    // Primarily drives:
-    // - fp_arith_inst_retired_256b_packed_double
-    // Uses FMA instructions; counts are still reflected in retired FP arithmetic events.
-    double* lhs = buffers.lhs;
-    double* rhs = buffers.rhs;
-    double* out = buffers.out;
-    int const count = buffers.count;
-    __m256d accum = _mm256_set1_pd(0.125);
-    __m256d shift = _mm256_setr_pd(0.25, 0.5, 0.75, 1.0);
-
-    for (int i = 0; i < count; i += 8) {
-        __m256d lhs0 = _mm256_loadu_pd(lhs + i);
-        __m256d rhs0 = _mm256_loadu_pd(rhs + i);
-        __m256d lhs1 = _mm256_loadu_pd(lhs + i + 4);
-        __m256d rhs1 = _mm256_loadu_pd(rhs + i + 4);
-
-        __m256d fused0 = _mm256_fmadd_pd(lhs0, rhs0, shift);
-        __m256d fused1 = _mm256_fnmadd_pd(lhs1, rhs1, shift);
-
-        accum = _mm256_add_pd(accum, _mm256_add_pd(fused0, fused1));
-
-        _mm256_storeu_pd(out + i, _mm256_add_pd(fused0, accum));
-        _mm256_storeu_pd(out + i + 4, _mm256_sub_pd(fused1, accum));
-    }
-
-    alignas(32) std::array<double, 4> lanes{};
-    _mm256_store_pd(lanes.data(), accum);
-    return lanes[0] + lanes[1] + lanes[2] + lanes[3] + out[count - 3];
-}
-
-__attribute__((target("avx2,fma"), noinline))
-double runAvx2FmaSingleKernel(PerfKernelBuffers const& buffers) {
-    // Primarily drives:
-    // - fp_arith_inst_retired_256b_packed_single
-    // Uses FMA instructions; counts are still reflected in retired FP arithmetic events.
-    float* lhs = buffers.lhs_f;
-    float* rhs = buffers.rhs_f;
-    float* out = buffers.out_f;
-    int const count = buffers.count;
-    __m256 accum = _mm256_set1_ps(0.125f);
-    __m256 shift = _mm256_setr_ps(0.25f, 0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f);
-
-    for (int i = 0; i < count; i += 16) {
-        __m256 lhs0 = _mm256_loadu_ps(lhs + i);
-        __m256 rhs0 = _mm256_loadu_ps(rhs + i);
-        __m256 lhs1 = _mm256_loadu_ps(lhs + i + 8);
-        __m256 rhs1 = _mm256_loadu_ps(rhs + i + 8);
-
-        __m256 fused0 = _mm256_fmadd_ps(lhs0, rhs0, shift);
-        __m256 fused1 = _mm256_fnmadd_ps(lhs1, rhs1, shift);
-
-        accum = _mm256_add_ps(accum, _mm256_add_ps(fused0, fused1));
-
-        _mm256_storeu_ps(out + i, _mm256_add_ps(fused0, accum));
-        _mm256_storeu_ps(out + i + 8, _mm256_sub_ps(fused1, accum));
-    }
-
-    alignas(32) std::array<float, 8> lanes{};
-    _mm256_store_ps(lanes.data(), accum);
-    double sum = static_cast<double>(out[count - 3]);
-    for (float value : lanes) {
-        sum += value;
-    }
-    return sum;
-}
-
 __attribute__((target("avx512f"), noinline))
-double runAvx512Kernel(PerfKernelBuffers const& buffers) {
-    // Primarily drives:
-    // - fp_arith_inst_retired_512b_packed_double
+double runAvx512DoubleKernel(PerfKernelBuffers const& buffers) {
     double* lhs = buffers.lhs;
     double* rhs = buffers.rhs;
     double* out = buffers.out;
     int const count = buffers.count;
+
     __m512d accum = _mm512_set1_pd(0.0625);
-    __m512d blend = _mm512_setr_pd(1.0, -1.0, 2.0, -2.0, 3.0, -3.0, 4.0, -4.0);
+    __m512d bias = _mm512_setr_pd(1.0, -1.0, 2.0, -2.0, 3.0, -3.0, 4.0, -4.0);
 
     for (int i = 0; i < count; i += 16) {
         __m512d lhs0 = _mm512_loadu_pd(lhs + i);
@@ -469,8 +362,8 @@ double runAvx512Kernel(PerfKernelBuffers const& buffers) {
         __m512d lhs1 = _mm512_loadu_pd(lhs + i + 8);
         __m512d rhs1 = _mm512_loadu_pd(rhs + i + 8);
 
-        __m512d mix0 = _mm512_add_pd(_mm512_mul_pd(lhs0, rhs0), blend);
-        __m512d mix1 = _mm512_sub_pd(_mm512_mul_pd(lhs1, rhs1), blend);
+        __m512d mix0 = _mm512_add_pd(_mm512_mul_pd(lhs0, rhs0), bias);
+        __m512d mix1 = _mm512_sub_pd(_mm512_mul_pd(lhs1, rhs1), bias);
 
         accum = _mm512_add_pd(accum, _mm512_add_pd(mix0, mix1));
 
@@ -480,20 +373,20 @@ double runAvx512Kernel(PerfKernelBuffers const& buffers) {
 
     alignas(64) std::array<double, 8> lanes{};
     _mm512_store_pd(lanes.data(), accum);
+
     return lanes[0] + lanes[1] + lanes[2] + lanes[3]
       + lanes[4] + lanes[5] + lanes[6] + lanes[7] + out[count - 4];
 }
 
 __attribute__((target("avx512f"), noinline))
 double runAvx512SingleKernel(PerfKernelBuffers const& buffers) {
-    // Primarily drives:
-    // - fp_arith_inst_retired_512b_packed_single
     float* lhs = buffers.lhs_f;
     float* rhs = buffers.rhs_f;
     float* out = buffers.out_f;
     int const count = buffers.count;
+
     __m512 accum = _mm512_set1_ps(0.0625f);
-    __m512 blend = _mm512_setr_ps(
+    __m512 bias = _mm512_setr_ps(
       1.0f, -1.0f, 2.0f, -2.0f, 3.0f, -3.0f, 4.0f, -4.0f,
       5.0f, -5.0f, 6.0f, -6.0f, 7.0f, -7.0f, 8.0f, -8.0f
     );
@@ -504,8 +397,8 @@ double runAvx512SingleKernel(PerfKernelBuffers const& buffers) {
         __m512 lhs1 = _mm512_loadu_ps(lhs + i + 16);
         __m512 rhs1 = _mm512_loadu_ps(rhs + i + 16);
 
-        __m512 mix0 = _mm512_add_ps(_mm512_mul_ps(lhs0, rhs0), blend);
-        __m512 mix1 = _mm512_sub_ps(_mm512_mul_ps(lhs1, rhs1), blend);
+        __m512 mix0 = _mm512_add_ps(_mm512_mul_ps(lhs0, rhs0), bias);
+        __m512 mix1 = _mm512_sub_ps(_mm512_mul_ps(lhs1, rhs1), bias);
 
         accum = _mm512_add_ps(accum, _mm512_add_ps(mix0, mix1));
 
@@ -515,6 +408,7 @@ double runAvx512SingleKernel(PerfKernelBuffers const& buffers) {
 
     alignas(64) std::array<float, 16> lanes{};
     _mm512_store_ps(lanes.data(), accum);
+
     double sum = static_cast<double>(out[count - 4]);
     for (float value : lanes) {
         sum += value;
@@ -525,13 +419,11 @@ double runAvx512SingleKernel(PerfKernelBuffers const& buffers) {
 #endif
 
 double runScalarPerfKernel(PerfKernelBuffers const& buffers) {
-    // Primarily drives:
-    // - fp_arith_inst_retired_scalar_double
-    // Also contributes to generic events such as instructions/cycles.
     double* lhs = buffers.lhs;
     double* rhs = buffers.rhs;
     double* out = buffers.out;
     int const count = buffers.count;
+
     double accum0 = 0.25;
     double accum1 = 0.75;
     double accum2 = -0.5;
@@ -550,14 +442,12 @@ double runScalarPerfKernel(PerfKernelBuffers const& buffers) {
 
 PerfMetricEstimate estimateScalarKernel(int count) {
     PerfMetricEstimate estimate;
-    // Heuristic scalar loop: 7 muls + 7 adds/subs per element.
     estimate.scalar_double = 14ULL * static_cast<std::uint64_t>(count);
     return estimate;
 }
 
 PerfMetricEstimate estimateSseScalarKernel(int count) {
     PerfMetricEstimate estimate;
-    // 2 muls + 1 add for each scalar double and scalar single lane.
     estimate.scalar_double = 3ULL * static_cast<std::uint64_t>(count);
     estimate.scalar_single = 3ULL * static_cast<std::uint64_t>(count);
     return estimate;
@@ -571,7 +461,7 @@ PerfMetricEstimate estimateSsePackedKernel(int count) {
     return estimate;
 }
 
-PerfMetricEstimate estimateAvxKernel(int count) {
+PerfMetricEstimate estimateAvxDoubleKernel(int count) {
     PerfMetricEstimate estimate;
     std::uint64_t const groups = static_cast<std::uint64_t>(count / 8);
     estimate.packed_256_double = 12ULL * groups;
@@ -585,28 +475,7 @@ PerfMetricEstimate estimateAvxSingleKernel(int count) {
     return estimate;
 }
 
-PerfMetricEstimate estimateAvxComplexKernel(int count) {
-    PerfMetricEstimate estimate;
-    std::uint64_t const groups = static_cast<std::uint64_t>(count / 4);
-    estimate.packed_256_double = 5ULL * groups;
-    return estimate;
-}
-
-PerfMetricEstimate estimateAvx2FmaKernel(int count) {
-    PerfMetricEstimate estimate;
-    std::uint64_t const groups = static_cast<std::uint64_t>(count / 8);
-    estimate.packed_256_double = 6ULL * groups;
-    return estimate;
-}
-
-PerfMetricEstimate estimateAvx2FmaSingleKernel(int count) {
-    PerfMetricEstimate estimate;
-    std::uint64_t const groups = static_cast<std::uint64_t>(count / 16);
-    estimate.packed_256_single = 6ULL * groups;
-    return estimate;
-}
-
-PerfMetricEstimate estimateAvx512Kernel(int count) {
+PerfMetricEstimate estimateAvx512DoubleKernel(int count) {
     PerfMetricEstimate estimate;
     std::uint64_t const groups = static_cast<std::uint64_t>(count / 16);
     estimate.packed_512_double = 8ULL * groups;
@@ -634,20 +503,12 @@ std::vector<PerfKernelDescriptor> buildPerfKernelDescriptors(int count) {
     }
 
     if (capabilities.avx) {
-        descriptors.push_back({"avx_double", runAvxKernel, estimateAvxKernel(count)});
+        descriptors.push_back({"avx_double", runAvxDoubleKernel, estimateAvxDoubleKernel(count)});
         descriptors.push_back({"avx_single", runAvxSingleKernel, estimateAvxSingleKernel(count)});
-        if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
-            descriptors.push_back({"avx_complex", runAvxComplexKernel, estimateAvxComplexKernel(count)});
-        }
-    }
-
-    if (capabilities.avx2_fma) {
-        descriptors.push_back({"avx2_fma_double", runAvx2FmaKernel, estimateAvx2FmaKernel(count)});
-        descriptors.push_back({"avx2_fma_single", runAvx2FmaSingleKernel, estimateAvx2FmaSingleKernel(count)});
     }
 
     if (capabilities.avx512f) {
-        descriptors.push_back({"avx512_double", runAvx512Kernel, estimateAvx512Kernel(count)});
+        descriptors.push_back({"avx512_double", runAvx512DoubleKernel, estimateAvx512DoubleKernel(count)});
         descriptors.push_back({"avx512_single", runAvx512SingleKernel, estimateAvx512SingleKernel(count)});
     }
 #endif
@@ -660,7 +521,6 @@ std::uint64_t shuffleSeedForBenchmark() {
     if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
         return kPerfShuffleSeed ^ 0x9e3779b97f4a7c15ULL;
     }
-
     return kPerfShuffleSeed;
 }
 
@@ -674,7 +534,7 @@ PerfSchedule buildPerfSchedule(int count) {
 
     for (PerfKernelDescriptor const& descriptor : descriptors) {
         for (int repeat = 0; repeat < kPerfKernelRepeatCount; ++repeat) {
-            schedule.kernels.push_back({descriptor.name, descriptor.function});
+            schedule.kernels.push_back({descriptor.function});
             addEstimate(schedule.ground_truth_per_iter, descriptor.estimate);
         }
     }
@@ -684,14 +544,10 @@ PerfSchedule buildPerfSchedule(int count) {
 }
 
 double runPerfInstructionMix(PerfKernelBuffers const& buffers, PerfSchedule const& schedule) {
-    // This intentionally mixes scalar/SSE/AVX/AVX2/FMA/AVX-512 kernels so that
-    // a wide VT_EVENTS list can be exercised in one short benchmark window.
-    // ISA-specific counters remain near zero when that ISA is unavailable.
     double checksum = 0.0;
     for (PerfKernelInvocation const& kernel : schedule.kernels) {
         checksum += kernel.function(buffers);
     }
-
     return checksum;
 }
 
@@ -709,6 +565,7 @@ benchmark_results_t runTimedPerfBenchmark(char const* benchmark_name, int iters)
         rhs[i] = 0.5 + static_cast<double>((i % 11) + 1) * 0.0625;
         lhs_f[i] = 1.0f + static_cast<float>((i % 13) + 1) * 0.125f;
         rhs_f[i] = 0.5f + static_cast<float>((i % 7) + 1) * 0.0625f;
+
         if constexpr (std::is_same_v<T, Kokkos::complex<double>>) {
             if ((i % 2) == 1) {
                 lhs[i] *= -1.0;
@@ -721,11 +578,14 @@ benchmark_results_t runTimedPerfBenchmark(char const* benchmark_name, int iters)
 
     std::vector<double> iter_timings;
     iter_timings.reserve(iters > kPerfWarmupIters ? iters - kPerfWarmupIters : 0);
+
     double total_time = 0.0;
     double checksum = 0.0;
+
     PerfKernelBuffers buffers{
       lhs.data(), rhs.data(), out.data(), lhs_f.data(), rhs_f.data(), out_f.data(), kPerfVectorLength
     };
+
     PerfSchedule const schedule = buildPerfSchedule<T>(kPerfVectorLength);
     PerfGroundTruth const ground_truth = scaleGroundTruth(schedule.ground_truth_per_iter, iters);
 

--- a/src/sensors.cc
+++ b/src/sensors.cc
@@ -5,6 +5,14 @@
 #include <cstdio>
 #include <cassert>
 #include <functional>
+#include <map>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <cctype>
+#include <optional>
+#include <cstdlib>
+#include <unistd.h>
 
 #include "sensors.h"
 #include "freq.h"
@@ -101,15 +109,285 @@ std::map<int, std::map<int,double>> parseSensorsOutput(FILE* pipe) {
   return socketCoreTemps;
 }
 
-std::map<int, std::map<int, double>> runSensors() {
+namespace {
+
+std::string trim(const std::string& input) {
+  auto begin = std::find_if_not(
+    input.begin(),
+    input.end(),
+    [](unsigned char c) { return std::isspace(c); }
+  );
+
+  auto end = std::find_if_not(
+    input.rbegin(),
+    input.rend(),
+    [](unsigned char c) { return std::isspace(c); }
+  ).base();
+
+  if (begin >= end) {
+    return "";
+  }
+
+  return std::string(begin, end);
+}
+
+std::optional<std::string> readTextFile(const std::filesystem::path& path) {
+  std::ifstream file(path);
+  if (!file) {
+    return std::nullopt;
+  }
+
+  std::ostringstream buffer;
+  buffer << file.rdbuf();
+  return trim(buffer.str());
+}
+
+bool executableExistsInPath(const std::string& executable) {
+  if (executable.find('/') != std::string::npos) {
+    return access(executable.c_str(), X_OK) == 0;
+  }
+
+  const char* pathEnv = std::getenv("PATH");
+  if (pathEnv == nullptr) {
+    return false;
+  }
+
+  std::stringstream pathStream(pathEnv);
+  std::string directory;
+
+  while (std::getline(pathStream, directory, ':')) {
+    if (directory.empty()) {
+      directory = ".";
+    }
+
+    std::filesystem::path candidate = std::filesystem::path(directory) / executable;
+
+    std::error_code ec;
+    if (
+      std::filesystem::exists(candidate, ec) &&
+      !std::filesystem::is_directory(candidate, ec) &&
+      access(candidate.c_str(), X_OK) == 0
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool parsePackageLabel(const std::string& label, int& socketId) {
+  std::istringstream iss(label);
+  std::string packageWord;
+  std::string idWord;
+
+  if (!(iss >> packageWord >> idWord >> socketId)) {
+    return false;
+  }
+
+  return packageWord == "Package" && idWord == "id";
+}
+
+bool parseCoreLabel(const std::string& label, int& coreNumber) {
+  std::istringstream iss(label);
+  std::string coreWord;
+
+  if (!(iss >> coreWord >> coreNumber)) {
+    return false;
+  }
+
+  return coreWord == "Core";
+}
+
+bool parseTempLabelIndex(const std::filesystem::path& path, int& index) {
+  const std::string filename = path.filename().string();
+
+  const std::string prefix = "temp";
+  const std::string suffix = "_label";
+
+  if (filename.size() <= prefix.size() + suffix.size()) {
+    return false;
+  }
+
+  if (filename.rfind(prefix, 0) != 0) {
+    return false;
+  }
+
+  if (filename.compare(filename.size() - suffix.size(), suffix.size(), suffix) != 0) {
+    return false;
+  }
+
+  const std::string indexString = filename.substr(
+    prefix.size(),
+    filename.size() - prefix.size() - suffix.size()
+  );
+
+  if (indexString.empty()) {
+    return false;
+  }
+
+  if (!std::all_of(indexString.begin(), indexString.end(), [](unsigned char c) {
+        return std::isdigit(c);
+      })) {
+    return false;
+  }
+
+  index = std::stoi(indexString);
+  return true;
+}
+
+struct HwmonTempEntry {
+  int index;
+  std::filesystem::path labelPath;
+  std::filesystem::path inputPath;
+};
+
+std::vector<HwmonTempEntry> getSortedTempLabelEntries(const std::filesystem::path& hwmonDir) {
+  std::vector<HwmonTempEntry> entries;
+
+  std::error_code ec;
+  std::filesystem::directory_iterator iterator(hwmonDir, ec);
+  if (ec) {
+    return entries;
+  }
+
+  for (const auto& entry : iterator) {
+    int index = -1;
+    if (!parseTempLabelIndex(entry.path(), index)) {
+      continue;
+    }
+
+    std::filesystem::path inputPath =
+      hwmonDir / ("temp" + std::to_string(index) + "_input");
+
+    if (!std::filesystem::exists(inputPath, ec)) {
+      continue;
+    }
+
+    entries.push_back(HwmonTempEntry{
+      index,
+      entry.path(),
+      inputPath
+    });
+  }
+
+  std::sort(
+    entries.begin(),
+    entries.end(),
+    [](const HwmonTempEntry& a, const HwmonTempEntry& b) {
+      return a.index < b.index;
+    }
+  );
+
+  return entries;
+}
+
+std::map<int, std::map<int, double>> readCoretempHwmon() {
+  std::map<int, std::map<int, double>> socketCoreTemps;
+
+  const std::filesystem::path hwmonRoot = "/sys/class/hwmon";
+
+  std::error_code ec;
+  if (!std::filesystem::exists(hwmonRoot, ec)) {
+    return socketCoreTemps;
+  }
+
+  std::filesystem::directory_iterator iterator(hwmonRoot, ec);
+  if (ec) {
+    return socketCoreTemps;
+  }
+
+  std::vector<std::filesystem::path> coretempHwmonDirs;
+
+  for (const auto& entry : iterator) {
+    if (!entry.is_directory(ec)) {
+      continue;
+    }
+
+    const std::filesystem::path hwmonDir = entry.path();
+    const std::filesystem::path namePath = hwmonDir / "name";
+
+    auto name = readTextFile(namePath);
+    if (!name.has_value()) {
+      continue;
+    }
+
+    if (*name == "coretemp") {
+      coretempHwmonDirs.push_back(hwmonDir);
+    }
+  }
+
+  std::sort(coretempHwmonDirs.begin(), coretempHwmonDirs.end());
+
+  for (const auto& hwmonDir : coretempHwmonDirs) {
+    int currentSocket = -1;
+
+    const auto tempEntries = getSortedTempLabelEntries(hwmonDir);
+
+    for (const auto& tempEntry : tempEntries) {
+      auto label = readTextFile(tempEntry.labelPath);
+      if (!label.has_value()) {
+        continue;
+      }
+
+      int socketId = -1;
+      if (parsePackageLabel(*label, socketId)) {
+        currentSocket = socketId;
+        if (socketCoreTemps.find(currentSocket) == socketCoreTemps.end()) {
+          socketCoreTemps[currentSocket] = std::map<int, double>();
+        }
+        continue;
+      }
+
+      int coreNumber = -1;
+      if (!parseCoreLabel(*label, coreNumber)) {
+        continue;
+      }
+
+      if (currentSocket == -1) {
+        continue;
+      }
+
+      auto input = readTextFile(tempEntry.inputPath);
+      if (!input.has_value()) {
+        continue;
+      }
+
+      double temperature = std::stod(*input) / 1000.0;
+
+      auto& coreMap = socketCoreTemps[currentSocket];
+      assert(coreMap.find(coreNumber) == coreMap.end()); // sanity check
+      coreMap[coreNumber] = temperature;
+    }
+  }
+
+  return socketCoreTemps;
+}
+
+std::map<int, std::map<int, double>> runSensorsCommand() {
   FILE* pipe = popen("sensors", "r");
   if (!pipe) {
     std::cerr << "Error: Unable to run sensors command\n";
     return {};
   }
+
   auto socketCoreTemps = parseSensorsOutput(pipe);
   pclose(pipe);
+
   return socketCoreTemps;
+}
+
+} // anonymous namespace
+
+std::map<int, std::map<int, double>> runSensors() {
+  if (executableExistsInPath("sensors")) {
+    auto socketCoreTemps = runSensorsCommand();
+
+    if (!socketCoreTemps.empty()) {
+      return socketCoreTemps;
+    }
+  }
+
+  return readCoretempHwmon();
 }
 
 void getTempsAndOrders(
@@ -171,7 +449,8 @@ void writeSensorAndFreqData(
 }
 
 void runSensorsAndReduceOutput(const std::string& proc_name, std::string identifier) {
-  // Get output from `sensors` if available
+  // Get output from `sensors` if available. If `sensors` is not available,
+  // fall back to reading core temperatures directly from /sys/class/hwmon.
   auto socketCoreTemps = runSensors();
   if (socketCoreTemps.empty()) {
     return;

--- a/src/slow_node.cc
+++ b/src/slow_node.cc
@@ -1,137 +1,123 @@
-
+#include "benchmarks.h"
 #include "sensors.h"
 
-#include <mkl.h>
-#include <Kokkos_Random.hpp>
+#include <mpi.h>
+#include <Kokkos_Core.hpp>
 
+#ifdef VT_ENABLED
+#include <vt/transport.h>
+#endif
+
+#include <cstdlib>
 #include <iostream>
+#include <string>
+#include <vector>
 
-static int iters = 100;
-static int M = 128;
-static int N = 128;
-static int K = 128;
+namespace {
 
-std::tuple<std::vector<double>, double> runBenchmark() {
-  Kokkos::View<double**> A("A", M, N);
-  Kokkos::View<double**> B("B", N, K);
-  Kokkos::View<double**> C("C", M, K);
+int iters = 100;
+int N1 = 128;
+int M2 = 128;
+int N2 = 128;
+int M3 = 128;
+int N3 = 128;
+int K3 = 128;
+int N4 = 128;
 
-  double* A_ptr = A.data();
-  double* B_ptr = B.data();
-  double* C_ptr = C.data();
+void printUsage(char const* exe) {
+  std::cerr << "USAGE: " << exe
+            << " [--benchmark all|level1|level2|level3|dpotrf|perf]"
+            << " [iters [N1 M2 N2 M3 N3 K3 N4]]" << std::endl;
+}
 
-  Kokkos::Random_XorShift64_Pool pool(123);
-  Kokkos::fill_random(A, pool, 10.0);
-  Kokkos::fill_random(B, pool, 10.0);
+bool parseBenchmark(std::string const& name, benchmarks::benchmark_types& benchmark) {
+  if (name == "all") {
+    benchmark = benchmarks::num_benchmarks;
+  } else if (name == "level1") {
+    benchmark = benchmarks::level1;
+  } else if (name == "level2") {
+    benchmark = benchmarks::level2;
+  } else if (name == "level3") {
+    benchmark = benchmarks::level3;
+  } else if (name == "dpotrf") {
+    benchmark = benchmarks::dpotrf;
+  } else if (name == "perf") {
+    benchmark = benchmarks::perf;
+  } else {
+    return false;
+  }
+  return true;
+}
 
-  std::vector<double> iter_timings;
+} // namespace
 
-  double total_time = 0.0;
+/*
+ * USAGE: ./slow_node [--benchmark all|level1|level2|level3|dpotrf|perf]
+ *                    [iters [N1 M2 N2 M3 N3 K3 N4]]
+ */
+int main(int argc, char** argv) {
+  std::vector<int> sizes = {N1, M2, N2, M3, N3, K3, N4};
+  benchmarks::benchmark_types benchmark = benchmarks::num_benchmarks;
 
-  MPI_Barrier(MPI_COMM_WORLD);
+  int arg = 1;
+  if (argc > arg && std::string(argv[arg]) == "--benchmark") {
+    if (argc <= arg + 1 || !parseBenchmark(argv[arg + 1], benchmark)) {
+      printUsage(argv[0]);
+      return 1;
+    }
+    arg += 2;
+  }
 
-  for (int i = 0; i < iters; i++) {
-    Kokkos::Timer timer;
-    cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
-      M,         // number of rows in C (and A)
-      K,         // number of columns in C (and B)
-      N,         // shared inner dimension (columns of A, rows of B)
-      1.0,       // alpha
-      A_ptr,     // matrix A pointer
-      N,         // leading dimension of A (because A is M×N)
-      B_ptr,     // matrix B pointer
-      K,         // leading dimension of B (because B is N×K)
-      0.0,       // beta
-      C_ptr,     // matrix C pointer
-      K);        // leading dimension of C (because C is M×K)
-    Kokkos::fence();
-    // Do not count the first iteration
-    if (i > 0) {
-      double time = timer.seconds();
-      total_time += time;
-      iter_timings.push_back(time);
+  int const remaining = argc - arg;
+  if (remaining != 0) {
+    if (remaining != 1 && remaining != 8) {
+      printUsage(argv[0]);
+      return 1;
+    }
+
+    iters = std::atoi(argv[arg++]);
+    if (remaining == 8) {
+      sizes[0] = std::atoi(argv[arg++]);
+      sizes[1] = std::atoi(argv[arg++]);
+      sizes[2] = std::atoi(argv[arg++]);
+      sizes[3] = std::atoi(argv[arg++]);
+      sizes[4] = std::atoi(argv[arg++]);
+      sizes[5] = std::atoi(argv[arg++]);
+      sizes[6] = std::atoi(argv[arg++]);
     }
   }
 
-  int rank = -1;
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-
-  std::cout << "rank: " << rank << ", total_time=" << total_time << std::endl;
-
-  return std::make_tuple(iter_timings, total_time);
-}
-
-int main(int argc, char** argv) {
-  if (argc > 1) {
-    iters = atoi(argv[1]) + 1; // add one iteration since we will drop the first one
-    M = N = K = atoi(argv[2]);
-  }
-  std::cout << "iters: " << iters << ", M=N=K=" << M << std::endl;
+  std::cout << "iters: " << iters
+            << ", sizes=" << sizes[0] << "," << sizes[1] << "," << sizes[2]
+            << "," << sizes[3] << "," << sizes[4] << "," << sizes[5]
+            << "," << sizes[6] << std::endl;
 
   MPI_Init(&argc, &argv);
+  MPI_Comm comm = MPI_COMM_WORLD;
+#ifdef VT_ENABLED
+  vt::initialize(argc, argv, &comm);
+#endif
   Kokkos::initialize(argc, argv);
 
   int rank = -1;
-  int num_ranks = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-  MPI_Comm_size(MPI_COMM_WORLD, &num_ranks);
 
   char processor_name[MPI_MAX_PROCESSOR_NAME];
   int name_len;
   MPI_Get_processor_name(processor_name, &name_len);
 
   sensors::runSensorsAndReduceOutput(processor_name, "pre");
-  auto const& [iter_timings, total_time] = runBenchmark();
+  auto output = benchmark == benchmarks::num_benchmarks ?
+    benchmarks::runAllBenchmarks(sizes, iters + 1) :
+    benchmarks::runSelectedBenchmark(benchmark, sizes, iters + 1);
   sensors::runSensorsAndReduceOutput(processor_name, "post");
 
-  std::vector<double> all_times;
-  all_times.resize(num_ranks);
-
-  std::vector<double> all_iter_times;
-  all_iter_times.resize(num_ranks * iters);
-
-  std::vector<char> all_processor_names;
-  all_processor_names.resize(num_ranks * MPI_MAX_PROCESSOR_NAME);
-
-  if (rank == 0) {
-    std::cout << "num_ranks: " << num_ranks << std::endl;
-  }
-
-  MPI_Gather(
-    &total_time, 1, MPI_DOUBLE,
-    &all_times[0], 1, MPI_DOUBLE, 0,
-    MPI_COMM_WORLD
-  );
-
-  MPI_Gather(
-    &iter_timings[0], iters, MPI_DOUBLE,
-    &all_iter_times[0], iters, MPI_DOUBLE, 0,
-    MPI_COMM_WORLD
-  );
-
-  MPI_Gather(
-    &processor_name, MPI_MAX_PROCESSOR_NAME, MPI_CHAR,
-    &all_processor_names[0], MPI_MAX_PROCESSOR_NAME, MPI_CHAR, 0,
-    MPI_COMM_WORLD
-  );
-
-  if (rank == 0) {
-    int cur_rank = 0;
-    int cur = 0;
-    for (auto&& time : all_times) {
-      std::cout << "gather: " << cur_rank << " ("
-        << std::string(&all_processor_names[cur_rank * MPI_MAX_PROCESSOR_NAME])
-        << "): " << time << ": breakdown: ";
-      for (int i = cur; i < iters + cur; i++) {
-        std::cout << all_iter_times[i] << " ";
-      }
-      std::cout << std::endl;
-      cur += iters;
-      cur_rank++;
-    }
-  }
+  benchmarks::printBenchmarkOutput(output, iters);
 
   Kokkos::finalize();
+#ifdef VT_ENABLED
+  vt::finalize();
+#endif
   MPI_Finalize();
   return 0;
 }


### PR DESCRIPTION
Fixes #14

This supercedes #10 but does not include #12 ... we'll need some clean-up with the open PRs (specifically #11) after merging this

-----

## Usage

#### Main Benchmark

Run the benchmark by itself with:

```
export VT_EVENTS=cycles,instructions
OMP_NUM_THREADS=1 OMP_PROC_BIND=true mpiexec -n <NP> ./slow_node --benchmark perf 20
```

where `VT_EVENTS` can be a list of events (more than 3 will cause multiplexing) and the `perf 20` indicates that the perf benchmark will run for 20 loops.

#### Data Processing

The perf benchmark writes four files to the current working directory:
- `perf_ground_truth_complex.csv`
- `perf_ground_truth_double.csv`
- `perf_metrics_complex.csv`
- `perf_metrics_double.csv`

Move these into a new directory with the following naming convention:

`perf_[no]mp_<num_ranks>r_<num_loops>l`

For example:
- `perf_mp_48r_10l`: multiplexed run on 48 ranks for 10 loops
- `perf_nomp_48r_20l`: non-multiplexed run on 48 ranks for 20 loops

Then, put all of these `perf_*r*l` directories into a single `data` directory. On my system, I have:

```
slow-node-detector
   |__src
   |__detection
   |__build
   |__data
       |__ perf_mp_48r_10l
       |__ perf_mp_48r_20l
       |__ perf_mp_48r_40l
       |__ perf_nomp_48r_10l
       |__ perf_nomp_48r_20l
       |__ perf_nomp_48r_40l
```

#### Plotting

With this directory structure, the plotting scripts should "just work."

**plot_perf_counters.py**: This one takes in a single `perf_metrics_*.csv` file and plots all of the counts for all available metrics.

```sh
python plot_perf_counters.py -i data/<sub-dir>/perf_metrics_double.csv
```

You can exclude any metrics from the plot with `-e metric1,metric2`, or focus specific metrics with `-f metric1,metric2`. You can also plot in log scale with `-l`.

See `-h` for all available options.

**plot_perf_metric.py**: This one takes in the data directory above, with all of the specifically-named subdirectories, and compares all of the multiplexed and nonmultiplexed counts for a specific metric at various loop sizes

```sh
python plot_perf_metric.py -d data -m fp_256b_packed_double
```

You can exclude (`-e`) or focus (`-f`) loop counts on this one too. `-h` for all options.